### PR TITLE
fix: Dockerfile을 npm으로 통일하여 CI 실패 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:20.17.0 AS builder
 WORKDIR /app
 COPY . .
-RUN yarn install
-RUN yarn run build
+RUN npm install
+RUN npm run build
 
 FROM node:20.17.0-alpine
 WORKDIR /app


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- fix: Dockerfile을 npm으로 통일하여 CI 실패 해결

### ✨ 변경 내용  
---  

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker 이미지 빌드 과정에서 Yarn 대신 npm을 사용하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->