### PR TITLE
fix: 배포 소스 브랜치를 develop으로 통일

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,8 @@ jobs:
             
             # Git 저장소 업데이트
             git fetch origin
-            git reset --hard origin/feature/add-infisical-to-deploy
+            # git reset --hard origin/feature/add-infisical-to-deploy
+            git reset --hard origin/develop
             
             # Docker 이미지 업데이트
             aws ecr get-login-password --region ap-northeast-2 | \


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 배포 소스 브랜치를 develop으로 통일
### ✨ 변경 내용  
---  
- 소스 코드 리셋이 다른 브랜치로 잡혀있었음

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 워크플로우에서 Git 리셋 대상 브랜치를 `feature/add-infisical-to-deploy`에서 `develop`으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->