### PR TITLE
feat: 본인 리뷰일 경우 디스코드 알림 안 가도록 수정

### DIFF
--- a/.github/scripts/send_discord_notification.py
+++ b/.github/scripts/send_discord_notification.py
@@ -89,6 +89,11 @@ def main():
             print("Coderabbit bot review, skipping Discord notification.")
             return
 
+        # PR 작성자가 본인이면서 동시에 리뷰어인 경우 알림을 보내지 않음
+        if reviewer_github_id == pr["user"]["login"]:
+            print("PR author is reviewing their own PR, skipping Discord notification.")
+            return
+
         reviewer_discord_id = get_discord_id(reviewer_github_id)
         if reviewer_discord_id and reviewer_discord_id.isdigit():
             formatted_reviewer = f"<@{reviewer_discord_id}>"


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 본인 리뷰일 경우 디스코드 알림 안 가도록 수정

### ✨ 변경 내용  
---  
- [ ] 

### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능 없음

- 버그 수정
  - PR 작성자가 본인 PR을 리뷰한 경우 Discord 알림이 전송되지 않도록 처리하여 불필요한 자기 알림을 방지했습니다.

- 문서
  - 해당 동작에 대한 주석을 추가해 의도를 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->