### PR TITLE
feat(user): 마이프로필 조회/수정 및 공개 유저 상세 조회 API 추가

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="1bc16e1b-3917-4527-86e0-8363e4191255" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="TypeScript File" />
+      </list>
+    </option>
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "node.js.selected.package.tslint": "(autodetect)",
+    "ts.external.directory.path": "/Users/sangwonlee/Projects/recipot-add-google-login/recipot-backend/node_modules/typescript/lib"
+  }
+}]]></component>
+  <component name="TaskManager">
+    <servers />
+  </component>
+</project>

--- a/src/api/user/dto/update-my-profile.dto.ts
+++ b/src/api/user/dto/update-my-profile.dto.ts
@@ -1,0 +1,32 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Length,
+} from 'class-validator';
+
+export class UpdateMyProfileDto {
+  @ApiPropertyOptional({ example: '요리왕비룡', description: '닉네임' })
+  @IsOptional()
+  @IsString()
+  @Length(1, 50)
+  nickname?: string;
+
+  @ApiPropertyOptional({
+    example: 'https://cdn.example.com/avatar.png',
+    description: '프로필 이미지 주소',
+  })
+  @IsOptional()
+  @IsUrl()
+  profile_image_url?: string;
+
+  @ApiPropertyOptional({
+    example: false,
+    description: '최초 진입 여부(온보딩 완료 시 false)',
+  })
+  @IsOptional()
+  @IsBoolean()
+  is_first_entry?: boolean;
+}

--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -1,13 +1,16 @@
 import {
+  Body,
   Controller,
   Get,
   HttpStatus,
   Param,
   ParseIntPipe,
+  Patch,
   Request,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
   ApiResponse,
   ApiTags,
@@ -16,6 +19,10 @@ import {
 import { Public } from '@/api/auth/auth.decorators';
 import { ApiSuccessResponse } from '@/common/decorators/api-success-response.decorator';
 import { UserService } from './user.service';
+import { UserDto } from '@/api/user/dto/user.dto';
+import { ERROR_CODES } from '@/common/constants/error-codes';
+import { CustomException } from '@/common/exceptions/custom-exception';
+import { UpdateMyProfileDto } from '@/api/user/dto/update-my-profile.dto';
 
 @Controller({ path: 'user', version: '1' })
 @ApiTags('User')
@@ -24,63 +31,109 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   /**
-   * @description 유저를 상세조회한다.
-   */
-  @Get('/:id')
-  @Public()
-  @ApiOperation({ summary: '유저를 상세조회한다.' })
-  @ApiResponse({ status: HttpStatus.OK })
-  async getUser(@Param('id', ParseIntPipe) id: number) {
-    return await this.userService.findById(id);
-  }
-
-  /**
-   * @description 인증된 사용자의 프로필을 조회한다.
+   * @description 인증된 사용자의 프로필을 조회한다. (마이페이지 메인)
    */
   @Get('/profile/me')
   @ApiOperation({
-    summary: '인증된 사용자의 프로필 조회',
+    summary: '인증된 사용자의 프로필 조회 (마이페이지 메인)',
     description: 'JWT 토큰을 통해 인증된 현재 사용자의 프로필을 조회합니다.',
   })
-  @ApiSuccessResponse('프로필 조회 성공', {
-    type: 'object',
-    properties: {
-      id: { type: 'number', example: 1 },
-      email: { type: 'string', example: 'user@example.com' },
-      name: { type: 'string', example: '홍길동' },
+  @ApiSuccessResponse('프로필 조회 성공', { type: UserDto })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: '인증 실패',
+    schema: {
+      example: {
+        code: ERROR_CODES.AUTH_REQUIRED.code,
+        message: ERROR_CODES.AUTH_REQUIRED.message,
+      },
     },
   })
   @ApiResponse({
-    status: HttpStatus.UNAUTHORIZED,
-    description: '인증 실패',
+    status: HttpStatus.NOT_FOUND,
+    description: '사용자 없음',
+    schema: {
+      example: {
+        code: ERROR_CODES.USER_NOT_FOUND.code,
+        message: ERROR_CODES.USER_NOT_FOUND.message,
+      },
+    },
   })
   async getMyProfile(@Request() req: any) {
-    // JWT 가드를 통해 인증된 사용자 정보는 req.user에 자동으로 설정됨
-    const userId = req.user.userId;
-    return await this.userService.findById(userId);
+    const userId = req.user?.userId ?? req.user?.sub ?? req.user?.id ?? null;
+
+    if (!userId) throw new CustomException(ERROR_CODES.AUTH_REQUIRED);
+    return await this.userService.getByIdOrThrow(Number(userId));
   }
 
   /**
-   * @description 인증된 사용자의 프로필을 업데이트한다.
+   * @description 인증된 사용자의 프로필을 업데이트한다. (내 정보 설정 변경)
    */
-  @Get('/profile/update')
+  @Patch('/profile/update')
   @ApiOperation({
-    summary: '인증된 사용자의 프로필 업데이트',
+    summary: '인증된 사용자의 프로필 업데이트 (내 정보 설정 변경)',
     description:
-      'JWT 토큰을 통해 인증된 현재 사용자의 프로필을 업데이트합니다.',
+      'nickname, profile_image_url, is_first_entry 중 필요한 항목만 보냅니다.',
   })
-  @ApiSuccessResponse('프로필 업데이트 성공')
+  @ApiBody({ type: UpdateMyProfileDto })
+  @ApiSuccessResponse('프로필 업데이트 성공', { type: UserDto })
   @ApiResponse({
     status: HttpStatus.UNAUTHORIZED,
     description: '인증 실패',
+    schema: {
+      example: {
+        code: ERROR_CODES.AUTH_REQUIRED.code,
+        message: ERROR_CODES.AUTH_REQUIRED.message,
+      },
+    },
   })
-  async updateMyProfile(@Request() req: any) {
-    // JWT 가드를 통해 인증된 사용자 정보는 req.user에 자동으로 설정됨
-    const userId = req.user.userId;
-    return {
-      message: '프로필 업데이트 기능은 추후 구현 예정',
-      userId: userId,
-      user: req.user,
-    };
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: '사용자 없음',
+    schema: {
+      example: {
+        code: ERROR_CODES.USER_NOT_FOUND.code,
+        message: ERROR_CODES.USER_NOT_FOUND.message,
+      },
+    },
+  })
+  async updateMyProfile(@Request() req: any, @Body() dto: UpdateMyProfileDto) {
+    const userId = req.user?.userId ?? req.user?.sub ?? req.user?.id ?? null;
+
+    if (!userId) throw new CustomException(ERROR_CODES.AUTH_REQUIRED);
+    return await this.userService.updateMyProfile(Number(userId), dto);
   }
+
+  /**
+   * @description 유저를 상세조회한다. (공개)
+   *  ⚠️ 정적 경로보다 아래에 둡니다.
+   */
+  @Get('/:id')
+  @Public()
+  @ApiOperation({ summary: '유저 상세 조회 (public)' })
+  @ApiResponse({ status: HttpStatus.OK, type: UserDto })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: '사용자 없음',
+    schema: {
+      example: {
+        code: ERROR_CODES.USER_NOT_FOUND.code,
+        message: ERROR_CODES.USER_NOT_FOUND.message,
+      },
+    },
+  })
+  async getUser(@Param('id', ParseIntPipe) id: number) {
+    return await this.userService.getByIdOrThrow(id);
+  }
+
+  // /**
+  //  * @description 유저를 상세조회한다.
+  //  */
+  // @Get('/:id')
+  // @Public()
+  // @ApiOperation({ summary: '유저를 상세조회한다.' })
+  // @ApiResponse({ status: HttpStatus.OK })
+  // async getUser(@Param('id', ParseIntPipe) id: number) {
+  //   return await this.userService.findById(id);
+  // }
 }

--- a/src/api/user/user.service.ts
+++ b/src/api/user/user.service.ts
@@ -5,6 +5,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserDto } from './dto/user.dto';
+import { ERROR_CODES } from '@/common/constants/error-codes';
+import { CustomException } from '@/common/exceptions/custom-exception';
 
 @Injectable()
 export class UserService {
@@ -16,6 +18,17 @@ export class UserService {
     private readonly userRepository: Repository<User>,
   ) {
     this.logger = this.loggerFactory.create(UserService.name);
+  }
+
+  private toDto(user: User): UserDto {
+    return {
+      id: user.id,
+      email: user.email,
+      nickname: user.nickname,
+      profile_image_url: user.profile_image_url,
+      recipe_complete_count: user.recipe_complete_count,
+      is_first_entry: user.is_first_entry,
+    };
   }
 
   /**
@@ -33,23 +46,41 @@ export class UserService {
 
   /**
    * 사용자 ID로 사용자 정보를 조회합니다.
+   * 존재하지 않으면 null을 반환합니다.
    */
   async findById(id: number): Promise<UserDto | null> {
-    const user = await this.userRepository.findOne({
-      where: { id },
-    });
+    const user = await this.userRepository.findOne({ where: { id } });
+    return user ? this.toDto(user) : null;
+  }
 
-    if (!user) {
-      return null;
-    }
+  /**
+   * 사용자 ID로 조회 (없으면 에러코드로 예외)
+   */
+  async getByIdOrThrow(id: number): Promise<UserDto> {
+    const dto = await this.findById(id);
+    if (!dto) throw new CustomException(ERROR_CODES.USER_NOT_FOUND);
+    return dto;
+  }
 
-    return {
-      id: user.id,
-      email: user.email,
-      nickname: user.nickname,
-      profile_image_url: user.profile_image_url,
-      recipe_complete_count: user.recipe_complete_count,
-      is_first_entry: user.is_first_entry,
-    };
+  /**
+   * 인증된 사용자의 프로필을 업데이트합니다.
+   */
+  async updateMyProfile(
+    userId: number,
+    payload: Partial<
+      Pick<User, 'nickname' | 'profile_image_url' | 'is_first_entry'>
+    >,
+  ): Promise<UserDto> {
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) throw new CustomException(ERROR_CODES.USER_NOT_FOUND);
+
+    if (payload.nickname !== undefined) user.nickname = payload.nickname;
+    if (payload.profile_image_url !== undefined)
+      user.profile_image_url = payload.profile_image_url;
+    if (payload.is_first_entry !== undefined)
+      user.is_first_entry = payload.is_first_entry;
+
+    const saved = await this.userRepository.save(user);
+    return this.toDto(saved);
   }
 }


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- PR 개요를 입력해주세요.  

### ✨ 변경 내용  
---  
GET /v1/user/profile/me (인증 필요): JWT 기반 현재 사용자 프로필 조회
	•	PATCH /v1/user/profile/update (인증 필요): 닉네임/프로필이미지/첫 진입 여부 업데이트
	•	GET /v1/user/:id (공개): 특정 유저 상세 조회 (정적 경로보다 하단 배치)
	•	Swagger 데코레이터 추가: @ApiTags, @ApiBearerAuth, @ApiOperation, @ApiResponse, 커스텀   @ApiSuccessResponse
	•	에러 응답 스키마 정비: AUTH_REQUIRED, USER_NOT_FOUND 케이스 명시
	•	요청자 식별 로직 보강: req.user?.userId ?? sub ?? id 순으로 안전 파싱

리팩토링/코드 개선
	•	정적 경로 → 동적 경로(/:id) 순서 정리 (라우팅 충돌 예방)
	•	불필요 주석/구현 분기 정리 및 코드 가독성 향상
### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 마이페이지 프로필 조회 엔드포인트 제공(인증 필요) 및 공개 사용자 조회 추가
  * 프로필 업데이트 지원: 닉네임, 프로필 이미지 URL, 첫 방문 여부
* Documentation
  * API 문서에 요청 본문 스키마와 예시 추가
  * 401/404 등 에러 응답 사례와 설명 보강
* Improvements
  * 인증 사용자 식별 로직 보완 및 일관된 사용자 조회/예외 처리
* Chores
  * 개발 워크스페이스 설정 추가(IDE 구성)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->