### PR TITLE
refactor: 유저 API path 경로 수정

### DIFF
--- a/src/api/user-recipe-archive/user-recipe-archive.controller.ts
+++ b/src/api/user-recipe-archive/user-recipe-archive.controller.ts
@@ -26,7 +26,7 @@ import { ERROR_CODES } from '@/common/constants/error-codes';
 import { ApiErrorResponse } from '@/common/decorators/api-error-response.decorator';
 import { ApiSuccessResponse } from '@/common/decorators/api-success-response.decorator';
 
-@Controller({ path: 'user/recipes', version: '1' })
+@Controller({ path: 'users/recipes', version: '1' })
 @ApiTags('User Recipe Archive')
 @UseGuards(JwtGuard)
 @ApiBearerAuth('Authorization')

--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -32,7 +32,7 @@ import {
 } from './dto/save-user-ingredients-survey.dto';
 import { UserService } from './user.service';
 
-@Controller({ path: 'user', version: '1' })
+@Controller({ path: 'users', version: '1' })
 @ApiTags('User')
 @UseGuards(JwtGuard)
 @ApiBearerAuth('Authorization')

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -50,21 +50,21 @@ describe('UserController (E2E)', () => {
       expect(response.body.data).toHaveProperty('steps');
     });
 
-    it(`${TEST_TAGS.AUTHENTICATED} 2단계: 레시피 요리 시작 - /user/recipes/:recipeId/start (POST)`, async () => {
+    it(`${TEST_TAGS.AUTHENTICATED} 2단계: 레시피 요리 시작 - /users/recipes/:recipeId/start (POST)`, async () => {
       const response = await authenticatedRequest(
         app,
         'post',
-        `/v1/user/recipes/${testRecipeId}/start`,
+        `/v1/users/recipes/${testRecipeId}/start`,
       ).expect(HttpStatus.CREATED);
 
       expect(response.body.data).toBe(true);
     });
 
-    it(`${TEST_TAGS.AUTHENTICATED} 3단계: 레시피 요리 완료 - /user/recipes/:recipeId/complete (POST)`, async () => {
+    it(`${TEST_TAGS.AUTHENTICATED} 3단계: 레시피 요리 완료 - /users/recipes/:recipeId/complete (POST)`, async () => {
       const response = await authenticatedRequest(
         app,
         'post',
-        `/v1/user/recipes/${testRecipeId}/complete`,
+        `/v1/users/recipes/${testRecipeId}/complete`,
       ).expect(HttpStatus.CREATED);
 
       expect(response.body.data).toBe(true);
@@ -74,7 +74,7 @@ describe('UserController (E2E)', () => {
   describe('북마크 저장 -> 북마크 조회 -> 북마크 삭제 플로우', () => {
     const testRecipeId = 2; // 테스트용 레시피 ID
 
-    it(`${TEST_TAGS.AUTHENTICATED} 1단계: 레시피 북마크 - /user/recipes/bookmarks (POST)`, async () => {
+    it(`${TEST_TAGS.AUTHENTICATED} 1단계: 레시피 북마크 - /users/recipes/bookmarks (POST)`, async () => {
       const createBookmarkDto = {
         recipeId: testRecipeId,
       };
@@ -82,7 +82,7 @@ describe('UserController (E2E)', () => {
       const response = await authenticatedRequest(
         app,
         'post',
-        '/v1/user/recipes/bookmarks',
+        '/v1/users/recipes/bookmarks',
       )
         .send(createBookmarkDto)
         .expect(HttpStatus.CREATED);
@@ -90,11 +90,11 @@ describe('UserController (E2E)', () => {
       expect(response.body.data).toBe(true);
     });
 
-    it(`${TEST_TAGS.AUTHENTICATED} 2단계: 북마크 목록 조회 - /user/recipes/bookmarks (GET)`, async () => {
+    it(`${TEST_TAGS.AUTHENTICATED} 2단계: 북마크 목록 조회 - /users/recipes/bookmarks (GET)`, async () => {
       const response = await authenticatedRequest(
         app,
         'get',
-        '/v1/user/recipes/bookmarks',
+        '/v1/users/recipes/bookmarks',
       );
 
       expect(response.status).toBe(HttpStatus.OK);
@@ -106,11 +106,11 @@ describe('UserController (E2E)', () => {
       expect(Array.isArray(response.body.data.items)).toBe(true);
     });
 
-    it(`${TEST_TAGS.AUTHENTICATED} 3단계: 북마크 해제 - /user/recipes/bookmarks/:recipeId (DELETE)`, async () => {
+    it(`${TEST_TAGS.AUTHENTICATED} 3단계: 북마크 해제 - /users/recipes/bookmarks/:recipeId (DELETE)`, async () => {
       const response = await authenticatedRequest(
         app,
         'delete',
-        `/v1/user/recipes/bookmarks/${testRecipeId}`,
+        `/v1/users/recipes/bookmarks/${testRecipeId}`,
       ).expect(HttpStatus.OK);
 
       expect(response.body.data).toBe(true);
@@ -118,11 +118,11 @@ describe('UserController (E2E)', () => {
   });
 
   describe('완료한 레시피 조회 플로우', () => {
-    it(`${TEST_TAGS.AUTHENTICATED} 완료한 레시피 목록 조회 - /user/recipes/completed (GET)`, async () => {
+    it(`${TEST_TAGS.AUTHENTICATED} 완료한 레시피 목록 조회 - /users/recipes/completed (GET)`, async () => {
       const response = await authenticatedRequest(
         app,
         'get',
-        '/v1/user/recipes/completed',
+        '/v1/users/recipes/completed',
       );
 
       expect(response.status).toBe(HttpStatus.OK);
@@ -150,11 +150,11 @@ describe('UserController (E2E)', () => {
       }
     });
 
-    it(`${TEST_TAGS.AUTHENTICATED} 완료한 레시피 목록 조회 (페이지네이션) - /user/recipes/completed?page=1&limit=2 (GET)`, async () => {
+    it(`${TEST_TAGS.AUTHENTICATED} 완료한 레시피 목록 조회 (페이지네이션) - /users/recipes/completed?page=1&limit=2 (GET)`, async () => {
       const response = await authenticatedRequest(
         app,
         'get',
-        '/v1/user/recipes/completed?page=1&limit=2',
+        '/v1/users/recipes/completed?page=1&limit=2',
       );
 
       expect(response.status).toBe(HttpStatus.OK);


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 유저 API path 경로 수정

### ✨ 변경 내용  
---  
- [ ] (변경된 사항 요약) 
- [ ] (새로 추가된 기능이나 수정된 내용)  
- [ ] (리팩토링 및 코드 개선 사항)  

### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 사용자 관련 API 기본 경로를 /v1/user에서 /v1/users로 통일했습니다.
  - 사용자 레시피 보관소 엔드포인트를 /user/recipes에서 /users/recipes로 변경했습니다.
  - 기존 단수형 경로는 더 이상 동작하지 않을 수 있으므로 클라이언트 호출 경로를 업데이트하세요.

- Tests
  - E2E 테스트를 새로운 복수형(/users, /users/recipes) 경로로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->