### PR TITLE
fix: S3 업로드 파일에 public-read ACL 추가

### DIFF
--- a/src/api/upload/upload.service.ts
+++ b/src/api/upload/upload.service.ts
@@ -37,6 +37,7 @@ export class UploadService {
         Key: key,
         Body: file.buffer,
         ContentType: file.mimetype,
+        ACL: 'public-read',
       });
 
       await this.s3.send(command);


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- Access Control List에 public-read 권한 추가
### ✨ 변경 내용  
---  
- s3 public-read 권한을 추가함으로써 브라우저에서 이미지 바로 표시 가능하도록 함

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 업로드된 파일이 기본적으로 공개 읽기 권한으로 저장됩니다. 업로드 직후 생성된 URL로 누구나 바로 접근할 수 있어, 링크 공유와 임베드가 더 간편해졌습니다(로그인 불필요).

* **Bug Fixes**
  * 일부 환경에서 업로드 후 파일 접근 권한 오류로 미리보기/다운로드가 차단되던 문제가 해소되어, 공유 링크의 동작 일관성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->