### PR TITLE
feat: 프론트엔드 CORS 설정 추가

### DIFF
--- a/src/config/config.loader.ts
+++ b/src/config/config.loader.ts
@@ -47,5 +47,9 @@ export const loadConfig = async (env: NodeJS.ProcessEnv = process.env) => {
       password: env.DB_PASSWORD,
       database: env.DB_DATABASE,
     },
+
+    frontendUrl: {
+      urls: env.FRONTEND_URL,
+    },
   };
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,14 +19,29 @@ async function bootstrap() {
 
   const app = await NestFactory.create(AppModule);
 
-  // 전역 가드 설정 - Reflector를 app.get()으로 가져옴
-  const reflector = app.get('Reflector');
-  app.useGlobalGuards(new JwtGuard(reflector));
-
   const loggerFactory = app.get(LoggerFactoryService);
   const logger = loggerFactory.create(bootstrap.name);
 
   const config = app.get(ConfigService);
+
+  // CORS 설정 추가
+  const frontendUrls =
+    config.get<string>('frontendUrl.urls') || process.env.FRONTEND_URL;
+  const allowedOrigins = frontendUrls
+    ? frontendUrls.split(',').map((url) => url.trim())
+    : ['http://localhost:3000'];
+
+  app.enableCors({
+    origin: allowedOrigins,
+    credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+  });
+  logger.log(`CORS enabled for: ${allowedOrigins.join(', ')}`);
+
+  // 전역 가드 설정 - Reflector를 app.get()으로 가져옴
+  const reflector = app.get('Reflector');
+  app.useGlobalGuards(new JwtGuard(reflector));
 
   // 버전 관리 활성화 - 컨트롤러의 version 옵션 사용
   app.enableVersioning();


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 프론트엔드 CORS 설정 추가

### ✨ 변경 내용  
---  
- 프론트엔드 로컬과 배포 서버에 대한 CORS 설정 추가

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - CORS 지원을 도입하여 브라우저에서 API와 안전하게 통신할 수 있습니다.
  - 허용 오리진을 설정/환경변수로 지정할 수 있으며, 기본값은 http://localhost:3000 입니다.
  - 자격 증명, 선택적 메서드 및 헤더를 지원해 다양한 프런트엔드 시나리오에 대응합니다.
- 작업
  - 프런트엔드 접근 도메인을 구성할 수 있는 옵션을 추가했습니다(허용 오리진 관리 용이).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->