### PR TITLE
feat: 미작성 레시피 후기 목록 조회 기능 추가

### DIFF
--- a/src/api/user/dto/get-pending-reviews.dto.ts
+++ b/src/api/user/dto/get-pending-reviews.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetPendingReviewsResponseDto {
+  @ApiProperty({
+    description: '후기 미작성 완료 레시피 ID 목록',
+    example: [42, 38, 25],
+    type: [Number],
+  })
+  completedRecipeIds: number[];
+
+  @ApiProperty({
+    description: '미작성 후기 개수',
+    example: 3,
+  })
+  totalCount: number;
+}

--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -31,6 +31,7 @@ import {
   SaveUserIngredientsSurveyResponseDto,
 } from './dto/save-user-ingredients-survey.dto';
 import { UserService } from './user.service';
+import { GetPendingReviewsResponseDto } from './dto/get-pending-reviews.dto';
 
 @Controller({ path: 'users', version: '1' })
 @ApiTags('User')
@@ -155,6 +156,39 @@ export class UserController {
       userId: userId,
       user: req.user,
     };
+  }
+
+  /**
+   * @description 24시간 이상 경과한 미작성 후기 목록을 조회합니다.
+   */
+  @Get('pending-reviews')
+  @ApiOperation({
+    summary: '미작성 레시피 후기 목록 조회 (24시간 경과)',
+    description:
+      '레시피 완료 후 24시간이 지났지만 후기를 작성하지 않은 완료 레시피 ID 목록을 조회합니다. 상세 정보는 /v1/reviews/preparation API로 조회하세요.',
+  })
+  @ApiSuccessResponse('미작성 후기 목록 조회 성공', {
+    type: 'object',
+    properties: {
+      completedRecipeIds: {
+        type: 'array',
+        items: { type: 'number' },
+        example: [42, 38, 25],
+        description: '후기 미작성 완료 레시피 ID 목록',
+      },
+      totalCount: {
+        type: 'number',
+        example: 3,
+        description: '미작성 후기 개수',
+      },
+    },
+  })
+  @ApiErrorResponse(HttpStatus.UNAUTHORIZED, ERROR_CODES.AUTH_REQUIRED)
+  @ApiErrorResponse(HttpStatus.NOT_FOUND, ERROR_CODES.USER_NOT_FOUND)
+  async getPendingReviews(
+    @Request() req: any,
+  ): Promise<GetPendingReviewsResponseDto> {
+    return await this.userService.getPendingReviews(req.user.sub);
   }
 
   /**

--- a/src/api/user/user.service.ts
+++ b/src/api/user/user.service.ts
@@ -9,7 +9,7 @@ import { UserRecipeBookmark } from '@/database/entity/user-recipe-bookmark.entit
 import { User } from '@/database/entity/user.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { LessThan, Repository } from 'typeorm';
 import { ERROR_CODES } from '../../common/constants/error-codes';
 import { CustomException } from '../../common/exceptions/custom-exception';
 import { SocialLoginService } from '../social-login/social-login.service';
@@ -26,6 +26,7 @@ import { UserDto } from './dto/user.dto';
 import { UserRole } from './enums/role.enum';
 import { UserRecentRecipesCustomRepository } from './user-recent-recipes.custom-repository';
 import { UserRecipeBookmarkCustomRepository } from './user-recipe-bookmark.custom-repository';
+import { GetPendingReviewsResponseDto } from './dto/get-pending-reviews.dto';
 
 @Injectable()
 export class UserService {
@@ -396,5 +397,33 @@ export class UserService {
     await this.userCompletedRecipeRepository.save(entity);
 
     return true;
+  }
+
+  async getPendingReviews(
+    userId: number,
+  ): Promise<GetPendingReviewsResponseDto> {
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new CustomException(ERROR_CODES.USER_NOT_FOUND);
+    }
+    const twentyFourHoursAgo = new Date();
+    twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24);
+    const completedRecipes = await this.userCompletedRecipeRepository.find({
+      where: {
+        userId,
+        isCompleted: true,
+        isReviewed: false,
+        updatedAt: LessThan(twentyFourHoursAgo),
+      },
+      order: {
+        updatedAt: 'DESC',
+      },
+    });
+    const completedRecipeIds = completedRecipes.map((recipe) => recipe.id);
+    console.log(completedRecipeIds);
+    return {
+      totalCount: completedRecipes.length,
+      completedRecipeIds,
+    };
   }
 }


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 미작성 레시피 후기 목록 조회 기능 추가

### ✨ 변경 내용  
---  
- 유저가 요리 완료 후 24시간이 지났음에도 후기를 작성하지 않은 데이터의 id 리스트 반환

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 인증된 사용자가 24시간 경과 후 아직 리뷰를 작성하지 않은 레시피를 조회하는 엔드포인트가 추가되었습니다. 미작성 레시피 ID 목록과 총 개수를 반환합니다.
- 문서
  - 새 엔드포인트와 응답 형식이 API 문서에 추가되어 요청/응답 예시와 상태 코드가 확인 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->