### PR TITLE
feat: 재료 목록 조회 기능 수정: 응답값에 카테고리 아이디, 카테고리 네임, 못 먹는 음식 여부 추가

### DIFF
--- a/src/api/ingredient/dto/get-ingredients.dto.ts
+++ b/src/api/ingredient/dto/get-ingredients.dto.ts
@@ -2,6 +2,20 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class IngredientItemDto {
   @ApiProperty({
+    description: '카테고리 ID',
+    example: 1,
+    type: 'number',
+  })
+  categoryId: number;
+
+  @ApiProperty({
+    description: '카테고리 이름',
+    example: '해산물류',
+    type: 'string',
+  })
+  categoryName: string;
+
+  @ApiProperty({
     description: '재료 ID',
     example: 1,
     type: 'number',
@@ -14,6 +28,13 @@ export class IngredientItemDto {
     type: 'string',
   })
   name: string;
+
+  @ApiProperty({
+    description: '사용자가 못 먹는 음식 여부',
+    example: false,
+    type: 'boolean',
+  })
+  isUserRestricted: boolean;
 }
 
 export class GetIngredientsResponseDto {

--- a/src/api/ingredient/ingredient.controller.ts
+++ b/src/api/ingredient/ingredient.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,
@@ -22,6 +30,7 @@ import {
   IngredientResponseDto,
 } from './dto/create-ingredient.dto';
 import { GetIngredientsResponseDto } from './dto/get-ingredients.dto';
+import { JwtGuard } from '../auth/guards/auth.guard';
 
 @ApiTags('재료')
 @Controller({ path: 'ingredients', version: '1' })
@@ -30,6 +39,7 @@ export class IngredientController {
   constructor(private readonly ingredientService: IngredientService) {}
 
   @Get()
+  @UseGuards(JwtGuard)
   @ApiOperation({
     summary: '재료 목록 조회',
     description: '모든 재료를 조회합니다.',
@@ -42,15 +52,24 @@ export class IngredientController {
         items: {
           type: 'object',
           properties: {
+            categoryId: { type: 'number', example: 1 },
+            categoryName: { type: 'string', example: '해산물류' },
             id: { type: 'number', example: 1 },
             name: { type: 'string', example: '고등어' },
+            isUserRestricted: {
+              type: 'boolean',
+              example: false,
+              description: '사용자가 못 먹는 재료 여부',
+            },
           },
         },
       },
     },
   })
-  async getIngredients(): Promise<GetIngredientsResponseDto> {
-    return await this.ingredientService.getIngredients();
+  async getIngredients(
+    @Request() req: any,
+  ): Promise<GetIngredientsResponseDto> {
+    return await this.ingredientService.getIngredients(req.user.sub);
   }
 
   @Get('admin/categories')

--- a/src/api/ingredient/ingredient.module.ts
+++ b/src/api/ingredient/ingredient.module.ts
@@ -5,6 +5,7 @@ import { IngredientCategory } from '@/database/entity/ingredient-category.entity
 import { IngredientController } from './ingredient.controller';
 import { IngredientHealthInfo } from '@/database/entity/ingredient-health-info.entity';
 import { Ingredient } from '@/database/entity/ingredient.entity';
+import { UserUnavailableIngredient } from '@/database/entity/user-unavailable-ingredient.entity';
 
 @Module({
   imports: [
@@ -12,6 +13,7 @@ import { Ingredient } from '@/database/entity/ingredient.entity';
       IngredientCategory,
       Ingredient,
       IngredientHealthInfo,
+      UserUnavailableIngredient,
     ]),
   ],
   controllers: [IngredientController],

--- a/src/api/ingredient/ingredient.service.ts
+++ b/src/api/ingredient/ingredient.service.ts
@@ -16,6 +16,7 @@ import {
   IngredientResponseDto,
 } from './dto/create-ingredient.dto';
 import { GetIngredientsResponseDto } from './dto/get-ingredients.dto';
+import { UserUnavailableIngredient } from '@/database/entity/user-unavailable-ingredient.entity';
 
 @Injectable()
 export class IngredientService {
@@ -28,6 +29,8 @@ export class IngredientService {
     private readonly ingredientRepository: Repository<Ingredient>,
     @InjectRepository(IngredientHealthInfo)
     private readonly ingredientHealthInfoRepository: Repository<IngredientHealthInfo>,
+    @InjectRepository(UserUnavailableIngredient) // ✅ 추가
+    private readonly userUnavailableIngredientRepository: Repository<UserUnavailableIngredient>,
   ) {}
 
   /**
@@ -137,17 +140,33 @@ export class IngredientService {
   /**
    * 재료 목록 조회
    */
-  async getIngredients(): Promise<GetIngredientsResponseDto> {
+  async getIngredients(userId: number): Promise<GetIngredientsResponseDto> {
     const ingredients = await this.ingredientRepository.find({
-      order: {
-        id: 'ASC',
-      },
+      order: { id: 'ASC' },
     });
-
+    const categoryIds = [
+      ...new Set(ingredients.map((i) => i.ingredientCategoryId)),
+    ];
+    const categories = await this.ingredientCategoryRepository.find({
+      where: { id: In(categoryIds) },
+    });
+    const categoryMap = new Map(categories.map((c) => [c.id, c.name]));
+    const unavailableIngredients =
+      await this.userUnavailableIngredientRepository.find({
+        where: { userId },
+        select: ['ingredientId'],
+      });
+    const unavailableIngredientIds = new Set(
+      unavailableIngredients.map((item) => item.ingredientId),
+    );
     return {
       data: ingredients.map((ingredient) => ({
         id: ingredient.id,
         name: ingredient.name,
+        categoryId: ingredient.ingredientCategoryId,
+        categoryName:
+          categoryMap.get(ingredient.ingredientCategoryId) || '미분류',
+        isUserRestricted: unavailableIngredientIds.has(ingredient.id),
       })),
     };
   }


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 재료 목록 조회 기능 수정: 응답값에 카테고리 아이디, 카테고리 네임, 못 먹는 음식 여부 추가

### ✨ 변경 내용  
---  
- 기존의 재료 목록 조회 기능의 응답에 카테고리 아이디, 카테고리 네임 그리고 못 먹는 음식 여부(boolean) 추가

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 재료 목록 응답에 카테고리 정보가 추가되었습니다: categoryId, categoryName.
  * 사용자가 먹지 못하는 재료 여부가 표시됩니다: isUserRestricted(개인 설정 반영).
  * 재료 목록 조회는 이제 인증이 필요합니다. 로그인 후 이용해 주세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->