### PR TITLE
feat: 레시피 테이블에서 컨디션 아이디 제거 및 관련 비즈니스 로직 제거

### DIFF
--- a/src/api/recipe/dto/create-recipe.dto.ts
+++ b/src/api/recipe/dto/create-recipe.dto.ts
@@ -161,14 +161,6 @@ export class CreateRecipeDto {
   method: string;
 
   @ApiProperty({
-    description: '컨디션 ID',
-    example: 1,
-  })
-  @IsInt()
-  @IsNotEmpty()
-  conditionId: number;
-
-  @ApiProperty({
     description: '레시피 이미지들',
     type: [CreateRecipeImageDto],
   })

--- a/src/api/recipe/dto/get-recipe.dto.ts
+++ b/src/api/recipe/dto/get-recipe.dto.ts
@@ -131,22 +131,6 @@ export class RecipeStepDto {
   summary: string;
 }
 
-export class RecipeConditionDto {
-  @ApiProperty({
-    description: '컨디션 ID',
-    example: 1,
-    type: 'number',
-  })
-  id: number;
-
-  @ApiProperty({
-    description: '컨디션 이름',
-    example: '힘들어',
-    type: 'string',
-  })
-  name: string;
-}
-
 export class RecipeHealthPointDto {
   @ApiProperty({
     description: '건강 포인트 내용',
@@ -184,12 +168,6 @@ export class GetRecipeResponseDto {
     type: 'string',
   })
   duration: string;
-
-  @ApiProperty({
-    description: '컨디션 정보',
-    type: RecipeConditionDto,
-  })
-  condition: RecipeConditionDto;
 
   @ApiProperty({
     description: '레시피 이미지 배열',

--- a/src/api/recipe/recipe.module.ts
+++ b/src/api/recipe/recipe.module.ts
@@ -9,7 +9,6 @@ import { RecipeSeasoning } from '@/database/entity/recipe-seasoning.entity';
 import { RecipeTool } from '@/database/entity/recipe-tool.entity';
 import { RecipeStep } from '@/database/entity/recipe-step.entity';
 import { RecipeHealthPoint } from '@/database/entity/recipe-health-point.entity';
-import { Condition } from '@/database/entity/condition.entity';
 import { Ingredient } from '@/database/entity/ingredient.entity';
 import { Seasoning } from '@/database/entity/seasoning.entity';
 import { Tool } from '@/database/entity/tool.entity';
@@ -26,7 +25,6 @@ import { CommonCodeModule } from '../common-code/common-code.module';
       RecipeTool,
       RecipeStep,
       RecipeHealthPoint,
-      Condition,
       Ingredient,
       Seasoning,
       Tool,

--- a/src/api/recipe/recipe.service.ts
+++ b/src/api/recipe/recipe.service.ts
@@ -9,7 +9,6 @@ import { RecipeSeasoning } from '@/database/entity/recipe-seasoning.entity';
 import { RecipeTool } from '@/database/entity/recipe-tool.entity';
 import { RecipeStep } from '@/database/entity/recipe-step.entity';
 import { RecipeHealthPoint } from '@/database/entity/recipe-health-point.entity';
-import { Condition } from '@/database/entity/condition.entity';
 import { Ingredient } from '@/database/entity/ingredient.entity';
 import { Seasoning } from '@/database/entity/seasoning.entity';
 import { Tool } from '@/database/entity/tool.entity';
@@ -49,8 +48,6 @@ export class RecipeService {
     private readonly recipeStepRepository: Repository<RecipeStep>,
     @InjectRepository(RecipeHealthPoint)
     private readonly recipeHealthPointRepository: Repository<RecipeHealthPoint>,
-    @InjectRepository(Condition)
-    private readonly conditionRepository: Repository<Condition>,
     @InjectRepository(Ingredient)
     private readonly ingredientRepository: Repository<Ingredient>,
     @InjectRepository(Seasoning)
@@ -70,7 +67,6 @@ export class RecipeService {
         duration: createRecipeDto.duration,
         level: createRecipeDto.level,
         method: createRecipeDto.method,
-        conditionId: createRecipeDto.conditionId,
       });
       const savedRecipe = await this.recipeRepository.save(recipe);
 
@@ -177,7 +173,6 @@ export class RecipeService {
       }
 
       const [
-        condition,
         images,
         recipeIngredients,
         recipeSeasonings,
@@ -185,7 +180,6 @@ export class RecipeService {
         steps,
         healthPoints,
       ] = await Promise.all([
-        this.conditionRepository.findOne({ where: { id: recipe.conditionId } }),
         this.recipeImageRepository.find({ where: { recipeId } }),
         this.recipeIngredientRepository.find({ where: { recipeId } }),
         this.recipeSeasoningRepository.find({ where: { recipeId } }),
@@ -193,10 +187,6 @@ export class RecipeService {
         this.recipeStepRepository.find({ where: { recipeId } }),
         this.recipeHealthPointRepository.find({ where: { recipeId } }),
       ]);
-
-      if (!condition) {
-        throw new CustomException(ERROR_CODES.CONDITION_NOT_FOUND);
-      }
 
       const ingredientIds = recipeIngredients.map((item) => item.ingredientId);
       const seasoningIds = recipeSeasonings.map((item) => item.seasoningId);
@@ -244,10 +234,6 @@ export class RecipeService {
         title: recipe.title,
         description: recipe.description,
         duration: durationName.codeName,
-        condition: {
-          id: condition.id,
-          name: condition.name,
-        },
         images: images.map((image) => ({
           id: image.id,
           imageUrl: image.imageUrl,

--- a/src/api/user/user.service.spec.ts
+++ b/src/api/user/user.service.spec.ts
@@ -69,7 +69,6 @@ describe('UserService', () => {
     duration: '30분',
     level: '초급',
     method: '볶음',
-    conditionId: 1,
     createdAt: new Date(),
     updatedAt: new Date(),
   } as Recipe;

--- a/src/database/entity/recipe.entity.ts
+++ b/src/database/entity/recipe.entity.ts
@@ -36,12 +36,4 @@ export class Recipe extends CommonEntity {
     comment: '조리 방식',
   })
   method: string;
-
-  @Column({
-    type: 'int',
-    nullable: false,
-    name: 'condition_id',
-    comment: '컨디션 PK',
-  })
-  conditionId: number;
 }

--- a/src/database/migrations/20251015-UpdateRecipeTable.ts
+++ b/src/database/migrations/20251015-UpdateRecipeTable.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+module.exports = class Migration20251015204824 {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('recipes', 'condition_id');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'recipes',
+      new TableColumn({
+        name: 'condition_id',
+        type: 'int',
+        isNullable: false,
+        comment: '컨디션 PK',
+      }),
+    );
+  }
+};

--- a/src/database/seeds/recipe.seed.ts
+++ b/src/database/seeds/recipe.seed.ts
@@ -3,7 +3,6 @@ import { Recipe } from '../entity/recipe.entity';
 import { Ingredient } from '../entity/ingredient.entity';
 import { Seasoning } from '../entity/seasoning.entity';
 import { Tool } from '../entity/tool.entity';
-import { Condition } from '../entity/condition.entity';
 import { RecipeImage } from '../entity/recipe-image.entity';
 import { RecipeIngredient } from '../entity/recipe-ingredient.entity';
 import { RecipeSeasoning } from '../entity/recipe-seasoning.entity';
@@ -25,7 +24,6 @@ export class RecipeSeed {
     const ingredientRepository = this.dataSource.getRepository(Ingredient);
     const seasoningRepository = this.dataSource.getRepository(Seasoning);
     const toolRepository = this.dataSource.getRepository(Tool);
-    const conditionRepository = this.dataSource.getRepository(Condition);
     const recipeImageRepository = this.dataSource.getRepository(RecipeImage);
     const recipeIngredientRepository =
       this.dataSource.getRepository(RecipeIngredient);
@@ -40,13 +38,11 @@ export class RecipeSeed {
     const ingredients = await ingredientRepository.find();
     const seasonings = await seasoningRepository.find();
     const tools = await toolRepository.find();
-    const conditions = await conditionRepository.find();
 
     // Create maps for easy ID lookup
     const ingredientMap = new Map(ingredients.map((i) => [i.name, i.id]));
     const seasoningMap = new Map(seasonings.map((s) => [s.name, s.id]));
     const toolMap = new Map(tools.map((t) => [t.name, t.id]));
-    const conditionMap = new Map(conditions.map((c) => [c.name, c.id]));
 
     // --- Define 10 recipe data objects ---
     const recipesData = [
@@ -56,7 +52,6 @@ export class RecipeSeed {
         title: '돼지고기 김치찌개',
         description: '한국인의 소울푸드, 얼큰하고 맛있는 김치찌개입니다.',
         duration: 'R01003', // 30분 이내
-        conditionName: '그럭저럭',
         images: [{ imageUrl: 'https://i.imgur.com/kFDU54j.jpeg' }],
         ingredients: [
           {
@@ -102,7 +97,6 @@ export class RecipeSeed {
         title: '차돌박이 된장찌개',
         description: '구수한 된장과 고소한 차돌박이의 완벽한 조화',
         duration: 'R01003', // 30분 이내
-        conditionName: '그럭저럭',
         images: [{ imageUrl: 'https://i.imgur.com/A1O2d6c.jpeg' }],
         ingredients: [
           { name: '두부', amount: '1/2모', isAlternative: false },
@@ -147,7 +141,6 @@ export class RecipeSeed {
         title: '에어프라이어 고등어 구이',
         description: '냄새 걱정 없이 간편하게 만드는 담백한 고등어 구이',
         duration: 'R01002', // 20분 이내
-        conditionName: '그럭저럭',
         images: [{ imageUrl: 'https://i.imgur.com/4l8dJmN.jpeg' }],
         ingredients: [
           { name: '고등어', amount: '1마리', isAlternative: false },
@@ -182,7 +175,6 @@ export class RecipeSeed {
         title: '클래식 김치볶음밥',
         description: '누구나 좋아하는 기본에 충실한 김치볶음밥',
         duration: 'R01002', // 20분 이내
-        conditionName: '그럭저럭',
         images: [{ imageUrl: 'https://i.imgur.com/jgw82P3.jpeg' }],
         ingredients: [
           { name: '백미', amount: '1공기', isAlternative: false },
@@ -223,7 +215,6 @@ export class RecipeSeed {
         title: '바삭한 감자전',
         description: '겉은 바삭, 속은 쫀득! 막걸리를 부르는 감자전',
         duration: 'R01003', // 30분 이내
-        conditionName: '그럭저럭',
         images: [{ imageUrl: 'https://i.imgur.com/h9d8f2S.jpeg' }],
         ingredients: [
           { name: '감자', amount: '3개', isAlternative: false },
@@ -262,7 +253,6 @@ export class RecipeSeed {
         title: '초간단 참치마요 덮밥',
         description: '자취생 필수 레시피! 10분 완성 참치마요 덮밥',
         duration: 'R01001', // 10분 이내
-        conditionName: '그럭저럭',
         images: [{ imageUrl: 'https://i.imgur.com/tT4fE8t.jpeg' }],
         ingredients: [
           { name: '백미', amount: '1공기', isAlternative: false },
@@ -296,7 +286,6 @@ export class RecipeSeed {
         title: '학교 앞 추억의 떡볶이',
         description: '달콤하고 매콤한, 옛날 학교 앞에서 먹던 바로 그 맛!',
         duration: 'R01002', // 20분 이내
-        conditionName: '그럭저럭',
         images: [{ imageUrl: 'https://i.imgur.com/oB4dY6c.jpeg' }],
         ingredients: [
           { name: '밀떡', amount: '300g', isAlternative: true },
@@ -332,7 +321,6 @@ export class RecipeSeed {
         title: '시원한 어묵탕',
         description: '쌀쌀한 날 생각나는 뜨끈하고 시원한 국물의 어묵탕',
         duration: 'R01002', // 20분 이내
-        conditionName: '그럭저럭',
         images: [{ imageUrl: 'https://i.imgur.com/sJ5gX2e.jpeg' }],
         ingredients: [
           { name: '어묵', amount: '300g', isAlternative: false },
@@ -367,7 +355,6 @@ export class RecipeSeed {
         title: '기본 토마토 스파게티',
         description: '시판 소스로 간단하게 만드는 클래식 토마토 스파게티',
         duration: 'R01002', // 20분 이내
-        conditionName: '그럭저럭',
         images: [{ imageUrl: 'https://i.imgur.com/Y7aLp2p.jpeg' }],
         ingredients: [
           { name: '파스타', amount: '1인분', isAlternative: false },
@@ -412,7 +399,6 @@ export class RecipeSeed {
         title: '알리오 올리오 파스타',
         description: '마늘과 올리브유의 풍미가 가득한 기본 오일 파스타',
         duration: 'R01002', // 20분 이내
-        conditionName: '그럭저럭',
         images: [{ imageUrl: 'https://i.imgur.com/5gXyZ8R.jpeg' }],
         ingredients: [
           { name: '파스타', amount: '1인분', isAlternative: false },
@@ -457,7 +443,6 @@ export class RecipeSeed {
         title: data.title,
         description: data.description,
         duration: data.duration,
-        conditionId: conditionMap.get(data.conditionName),
       });
       const savedRecipe = await recipeRepository.save(recipe);
 


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 레시피 테이블에서 컨디션 아이디 제거 및 관련 비즈니스 로직 제거

### ✨ 변경 내용  
---  
- 레시피 테이블에서 저장하고 있던 conditionId 제거
- 레시피 생성, 조회 등의 비즈니스 로직에서 conditionId 제거

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 레시피 API에서 condition/conditionId 필드 전면 제거: 생성 요청 본문에서 입력 불필요, 조회 응답에서 조건 정보 미포함.
- Chores
  - 데이터 시드에서 condition 관련 항목 및 처리 로직 삭제.
  - 마이그레이션으로 recipes 테이블의 condition_id 컬럼 제거(다운 시 복원).
- Tests
  - 테스트 데이터에서 condition 참조 제거 및 기대값 정리.

주의: 기존 클라이언트는 condition/conditionId에 의존한 요청·응답 처리를 업데이트해야 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->