### PR TITLE
feat: 온보딩에 필요한 못 먹는 음식 목록 조회 기능 추가

### DIFF
--- a/src/api/ingredient/dto/get-restricted-ingredients.dto.ts
+++ b/src/api/ingredient/dto/get-restricted-ingredients.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RestrictedIngredientItemDto {
+  @ApiProperty({
+    type: Number,
+    description: '재료 ID',
+    example: 1,
+  })
+  id: number;
+
+  @ApiProperty({
+    type: String,
+    description: '재료 이름',
+    example: '연어',
+  })
+  name: string;
+
+  @ApiProperty({
+    type: Boolean,
+    description: '사용자가 선택한 못먹는 재료 여부',
+    example: false,
+  })
+  isUserRestricted: boolean;
+}
+
+export class GetRestrictedIngredientsResponseDto {
+  @ApiProperty({
+    type: [RestrictedIngredientItemDto],
+    description: '제한 재료 목록',
+  })
+  data: RestrictedIngredientItemDto[];
+}

--- a/src/api/ingredient/ingredient.controller.ts
+++ b/src/api/ingredient/ingredient.controller.ts
@@ -31,6 +31,7 @@ import {
 } from './dto/create-ingredient.dto';
 import { GetIngredientsResponseDto } from './dto/get-ingredients.dto';
 import { JwtGuard } from '../auth/guards/auth.guard';
+import { GetRestrictedIngredientsResponseDto } from './dto/get-restricted-ingredients.dto';
 
 @ApiTags('재료')
 @Controller({ path: 'ingredients', version: '1' })
@@ -70,6 +71,38 @@ export class IngredientController {
     @Request() req: any,
   ): Promise<GetIngredientsResponseDto> {
     return await this.ingredientService.getIngredients(req.user.sub);
+  }
+
+  @Get('restricted')
+  @UseGuards(JwtGuard)
+  @ApiOperation({
+    summary: '못 먹는 음식 목록 조회 (온보딩)',
+    description: '사용자가 선택할 수 있는 제한 재료 목록을 반환합니다.',
+  })
+  @ApiSuccessResponse('못 먹는 음식 조회 성공', {
+    type: 'object',
+    properties: {
+      data: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'number', example: 1 },
+            name: { type: 'string', example: '연어' },
+            isUserRestricted: {
+              type: 'boolean',
+              example: false,
+              description: '사용자가 선택한 못먹는 음식 여부',
+            },
+          },
+        },
+      },
+    },
+  })
+  async getRestrictedIngredients(
+    @Request() req: any,
+  ): Promise<GetRestrictedIngredientsResponseDto> {
+    return await this.ingredientService.getRestrictedIngredients(req.user.sub);
   }
 
   @Get('admin/categories')

--- a/src/api/ingredient/ingredient.service.ts
+++ b/src/api/ingredient/ingredient.service.ts
@@ -17,6 +17,7 @@ import {
 } from './dto/create-ingredient.dto';
 import { GetIngredientsResponseDto } from './dto/get-ingredients.dto';
 import { UserUnavailableIngredient } from '@/database/entity/user-unavailable-ingredient.entity';
+import { GetRestrictedIngredientsResponseDto } from './dto/get-restricted-ingredients.dto';
 
 @Injectable()
 export class IngredientService {
@@ -29,7 +30,7 @@ export class IngredientService {
     private readonly ingredientRepository: Repository<Ingredient>,
     @InjectRepository(IngredientHealthInfo)
     private readonly ingredientHealthInfoRepository: Repository<IngredientHealthInfo>,
-    @InjectRepository(UserUnavailableIngredient) // ✅ 추가
+    @InjectRepository(UserUnavailableIngredient)
     private readonly userUnavailableIngredientRepository: Repository<UserUnavailableIngredient>,
   ) {}
 
@@ -166,6 +167,33 @@ export class IngredientService {
         categoryId: ingredient.ingredientCategoryId,
         categoryName:
           categoryMap.get(ingredient.ingredientCategoryId) || '미분류',
+        isUserRestricted: unavailableIngredientIds.has(ingredient.id),
+      })),
+    };
+  }
+
+  /**
+   * 못먹는 음식 조회 (온보딩용)
+   */
+  async getRestrictedIngredients(
+    userId: number,
+  ): Promise<GetRestrictedIngredientsResponseDto> {
+    const restrictedIngredients = await this.ingredientRepository.find({
+      where: { isRestrictedIngredient: true },
+      order: { id: 'ASC' },
+    });
+    const unavailableIngredients =
+      await this.userUnavailableIngredientRepository.find({
+        where: { userId },
+        select: ['ingredientId'],
+      });
+    const unavailableIngredientIds = new Set(
+      unavailableIngredients.map((item) => item.ingredientId),
+    );
+    return {
+      data: restrictedIngredients.map((ingredient) => ({
+        id: ingredient.id,
+        name: ingredient.name,
         isUserRestricted: unavailableIngredientIds.has(ingredient.id),
       })),
     };

--- a/src/database/entity/ingredient.entity.ts
+++ b/src/database/entity/ingredient.entity.ts
@@ -15,4 +15,12 @@ export class Ingredient extends CommonEntity {
     comment: '재료 이름 (예: 고등어, 게 등)',
   })
   name: string;
+
+  @Column({
+    type: 'boolean',
+    name: 'is_restricted_ingredient',
+    default: false,
+    comment: '온보딩 단계에서 노출하는 제한 식품 여부',
+  })
+  isRestrictedIngredient: boolean;
 }

--- a/src/database/migrations/20251019-UpdateIngredientTable.ts
+++ b/src/database/migrations/20251019-UpdateIngredientTable.ts
@@ -1,0 +1,20 @@
+import { QueryRunner, Table, TableColumn } from 'typeorm';
+
+module.exports = class Migration20251019210331 {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'ingredients',
+      new TableColumn({
+        name: 'is_restricted_ingredient',
+        type: 'boolean',
+        default: false,
+        isNullable: false,
+        comment: '온보딩 단계에서 노출하는 제한 식품 여부',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('ingredients', 'is_restricted_ingredient');
+  }
+};

--- a/src/database/seeds/index.ts
+++ b/src/database/seeds/index.ts
@@ -6,6 +6,7 @@ import { SeasoningSeed } from './seasoning.seed';
 import { ToolSeed } from './tool.seed';
 import { ConditionSeed } from './condition.seed';
 import { RecipeSeed } from './recipe.seed';
+import { IngredientRestrictedSeed } from './ingredient-restricted.seed';
 
 export class DatabaseSeeder {
   constructor(
@@ -27,6 +28,12 @@ export class DatabaseSeeder {
     // IngredientSeed 실행
     const ingredientSeed = new IngredientSeed(this.dataSource);
     await ingredientSeed.run();
+
+    // IngredientRestrictedSeed
+    const ingredientRestrictedSeed = new IngredientRestrictedSeed(
+      this.dataSource,
+    );
+    await ingredientRestrictedSeed.run();
 
     // SeasoningSeed 실행
     const seasoningSeed = new SeasoningSeed(this.dataSource);

--- a/src/database/seeds/ingredient-restricted.seed.ts
+++ b/src/database/seeds/ingredient-restricted.seed.ts
@@ -15,6 +15,15 @@ export class IngredientRestrictedSeed {
     const ingredientRepository =
       this.dataSource.manager.getRepository(Ingredient);
 
+    const restrictedCount = await ingredientRepository.count({
+      where: { isRestrictedIngredient: true },
+    });
+
+    if (restrictedCount > 0) {
+      this.logger.log('Restricted ingredients already seeded, skipping...');
+      return;
+    }
+
     this.logger.log('Starting IngredientRestrictedSeed...');
 
     // 온보딩에 노출할 제한 식품 Set

--- a/src/database/seeds/ingredient-restricted.seed.ts
+++ b/src/database/seeds/ingredient-restricted.seed.ts
@@ -1,0 +1,174 @@
+import { DataSource } from 'typeorm';
+import { IngredientCategory } from '../entity/ingredient-category.entity';
+import { Ingredient } from '../entity/ingredient.entity';
+
+export class IngredientRestrictedSeed {
+  constructor(private dataSource: DataSource) {}
+
+  async run(): Promise<void> {
+    if (!this.dataSource || !this.dataSource.manager) {
+      throw new Error('DataSource or manager is not available');
+    }
+
+    const categoryRepository =
+      this.dataSource.manager.getRepository(IngredientCategory);
+    const ingredientRepository =
+      this.dataSource.manager.getRepository(Ingredient);
+
+    this.logger.log('Starting IngredientRestrictedSeed...');
+
+    // 온보딩에 노출할 제한 식품 Set
+    const restrictedIngredients = new Set([
+      // 곡류
+      '밀가루',
+      '메밀',
+      '부침가루',
+      '면',
+      '파스타',
+      '만두',
+      '빵',
+      // 어패류 (신규)
+      '참치',
+      '고등어',
+      '멸치',
+      '오징어',
+      '굴',
+      '바지락',
+      '연어',
+      '새우',
+      '홍합',
+      // 유제품
+      '우유',
+      '버터',
+      '치즈',
+      '요거트',
+      // 절임 및 발효식품
+      '새우젓',
+      '명란젓',
+      '액젓',
+      // 소스류
+      '마요네즈',
+      '마라',
+      // 가공식품류
+      '어묵',
+      '게맛살',
+      // 육류 및 계란 (신규 카테고리)
+      '닭고기',
+      '돼지고기',
+      '쇠고기',
+      '계란',
+      '메추리알',
+      '오리고기',
+      '햄',
+      '소시지',
+      '베이컨',
+      // 견과류 (신규 카테고리)
+      '땅콩',
+      '호두',
+      '캐슈넛',
+      '피스타치오',
+      '잣',
+      '땅콩버터',
+      // 과일 (신규 카테고리)
+      '복숭아',
+      '사과',
+      '배',
+    ]);
+
+    const newCategoriesWithIngredients = [
+      {
+        name: '육류 및 계란',
+        ingredients: [
+          '닭고기',
+          '돼지고기',
+          '쇠고기',
+          '계란',
+          '메추리알',
+          '오리고기',
+          '햄',
+          '소시지',
+          '베이컨',
+        ],
+      },
+      {
+        name: '견과류',
+        ingredients: ['땅콩', '호두', '캐슈넛', '피스타치오', '잣', '땅콩버터'],
+      },
+      {
+        name: '과일',
+        ingredients: ['복숭아', '사과', '배'],
+      },
+    ];
+
+    // 1. 새로운 카테고리 생성
+    for (const categoryData of newCategoriesWithIngredients) {
+      const existingCategory = await categoryRepository.findOneBy({
+        name: categoryData.name,
+      });
+
+      if (existingCategory) {
+        this.logger.log(`카테고리 '${categoryData.name}' 이미 존재, 스킵`);
+        continue;
+      }
+
+      const category = await categoryRepository.save({
+        name: categoryData.name,
+      });
+
+      const ingredients = categoryData.ingredients.map((ingredientName) => ({
+        name: ingredientName,
+        ingredientCategoryId: category.id,
+        isRestrictedIngredient: true,
+      }));
+
+      await ingredientRepository.save(ingredients);
+      this.logger.log(`카테고리 '${categoryData.name}' 생성 완료`);
+    }
+
+    // 2. 기존 카테고리에 신규 재료 추가 및 제한식품 플래그 업데이트
+    const seafoodCategory = await categoryRepository.findOneBy({
+      name: '어패류',
+    });
+
+    if (seafoodCategory) {
+      const newSeafoodItems = ['연어', '새우', '홍합'];
+
+      for (const ingredientName of newSeafoodItems) {
+        const existingIngredient = await ingredientRepository.findOneBy({
+          name: ingredientName,
+          ingredientCategoryId: seafoodCategory.id,
+        });
+
+        if (!existingIngredient) {
+          await ingredientRepository.save({
+            name: ingredientName,
+            ingredientCategoryId: seafoodCategory.id,
+            isRestrictedIngredient: true,
+          });
+          this.logger.log(`어패류에 '${ingredientName}' 추가`);
+        }
+      }
+    }
+
+    // 3. 기존 모든 재료의 isRestrictedIngredient 플래그 업데이트
+    const allIngredients = await ingredientRepository.find();
+
+    for (const ingredient of allIngredients) {
+      const shouldBeRestricted = restrictedIngredients.has(ingredient.name);
+
+      if (ingredient.isRestrictedIngredient !== shouldBeRestricted) {
+        ingredient.isRestrictedIngredient = shouldBeRestricted;
+        await ingredientRepository.save(ingredient);
+      }
+    }
+
+    this.logger.log('IngredientRestrictedSeed completed successfully');
+  }
+
+  private readonly logger = {
+    log: (message: string) =>
+      console.log(`[IngredientRestrictedSeed] ${message}`),
+    error: (message: string) =>
+      console.error(`[IngredientRestrictedSeed] ${message}`),
+  };
+}


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 온보딩에 필요한 못 먹는 음식 목록 조회 기능 추가  

### ✨ 변경 내용  
---  
- 재료 엔터티에 못 먹는 음식 범주에 포함되는 지 여부를 알려주는 isRestrictedIngredient 컬럼 추가
- 온보딩 과정에서 활용할 못 먹는 음식 목록 조회 기능 추가

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 제한 식재료 목록 조회용 새 API 엔드포인트 추가
  * 사용자별 제한 식재료 표시(사용자 제한 여부) 제공
  * 제한 식재료 조회 응답 형식 추가

* **Chores**
  * 데이터베이스에 제한 식재료 칼럼 및 마이그레이션 추가
  * 초기 제한 식재료 데이터 시드 및 동기화 작업 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->