### PR TITLE
feat: 유저 컨디션 관련 기능 추가

### DIFF
--- a/src/api/user-recipe-archive/user-recipe-archive.module.ts
+++ b/src/api/user-recipe-archive/user-recipe-archive.module.ts
@@ -17,6 +17,7 @@ import { UserRecipeBookmarkCustomRepository } from '@/api/user/user-recipe-bookm
 import { UserService } from '@/api/user/user.service';
 import { UserRecipeArchiveController } from './user-recipe-archive.controller';
 import { UserRecipeArchiveService } from './user-recipe-archive.service';
+import { UserDailyConditions } from '@/database/entity/user-daily-conditions.entity';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { UserRecipeArchiveService } from './user-recipe-archive.service';
       UserCompletedRecipe,
       Recipe,
       SocialLogin,
+      UserDailyConditions,
     ]),
     SocialLoginModule,
   ],

--- a/src/api/user/dto/get-user-condition.dto.ts
+++ b/src/api/user/dto/get-user-condition.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetUserConditionResponseDto {
+  @ApiProperty({
+    description: '사용자가 저장한 컨디션 ID (없으면 null)',
+    example: 1,
+    type: Number,
+    nullable: true,
+  })
+  conditionId: number | null;
+}

--- a/src/api/user/dto/save-user-condition.dto.ts
+++ b/src/api/user/dto/save-user-condition.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsNumber } from 'class-validator';
+
+export class SaveUserConditionDto {
+  @ApiProperty({
+    description: '컨디션 ID',
+    example: 1,
+    type: Number,
+  })
+  @IsNumber()
+  conditionId: number;
+
+  @ApiProperty({
+    description: '추천 단계까지 진행했는지 여부',
+    example: false,
+    type: Boolean,
+  })
+  @IsBoolean()
+  isRecommendationStarted: boolean;
+}
+
+export class SaveUserConditionResponseDto {
+  @ApiProperty({
+    description: '저장된 컨디션 ID',
+    example: 1,
+    type: Number,
+  })
+  conditionId: number;
+}

--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -32,6 +32,10 @@ import {
 } from './dto/save-user-ingredients-survey.dto';
 import { UserService } from './user.service';
 import { GetPendingReviewsResponseDto } from './dto/get-pending-reviews.dto';
+import {
+  SaveUserConditionDto,
+  SaveUserConditionResponseDto,
+} from './dto/save-user-condition.dto';
 
 @Controller({ path: 'users', version: '1' })
 @ApiTags('User')
@@ -111,6 +115,26 @@ export class UserController {
   ): Promise<SaveUserIngredientsSurveyResponseDto> {
     const userId = req.user.sub;
     return await this.userService.saveUserIngredientsSurvey(userId, surveyDto);
+  }
+
+  /**
+   * @description 사용자의 컨디션을 저장합니다.
+   */
+  @Post('/conditions/daily')
+  @ApiOperation({
+    summary: '컨디션 저장',
+    description:
+      '사용자가 선택한 컨디션을 저장합니다. 추천 단계 진행 여부에 따라 캐시 또는 DB에 저장합니다.',
+  })
+  @ApiSuccessResponse('컨디션 저장 성공', SaveUserConditionResponseDto)
+  @ApiErrorResponse(HttpStatus.UNAUTHORIZED, ERROR_CODES.AUTH_REQUIRED)
+  @ApiErrorResponse(HttpStatus.NOT_FOUND, ERROR_CODES.USER_NOT_FOUND)
+  async saveUserCondition(
+    @Request() req: any,
+    @Body() conditionDto: SaveUserConditionDto,
+  ): Promise<SaveUserConditionResponseDto> {
+    const userId = req.user.sub;
+    return await this.userService.saveUserCondition(userId, conditionDto);
   }
 
   /**

--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -36,6 +36,7 @@ import {
   SaveUserConditionDto,
   SaveUserConditionResponseDto,
 } from './dto/save-user-condition.dto';
+import { GetUserConditionResponseDto } from './dto/get-user-condition.dto';
 
 @Controller({ path: 'users', version: '1' })
 @ApiTags('User')
@@ -135,6 +136,32 @@ export class UserController {
   ): Promise<SaveUserConditionResponseDto> {
     const userId = req.user.sub;
     return await this.userService.saveUserCondition(userId, conditionDto);
+  }
+
+  @Get('/conditions/daily')
+  @ApiOperation({
+    summary: '컨디션 조회',
+    description:
+      '사용자가 저장한 일일 컨디션을 조회합니다. 캐시에서 조회하며, 없으면 null을 반환합니다.',
+  })
+  @ApiSuccessResponse('컨디션 조회 성공', {
+    type: 'object',
+    properties: {
+      conditionId: {
+        type: 'number',
+        example: 1,
+        nullable: true,
+        description: '저장된 컨디션 ID (없으면 null)',
+      },
+    },
+  })
+  @ApiErrorResponse(HttpStatus.UNAUTHORIZED, ERROR_CODES.AUTH_REQUIRED)
+  @ApiErrorResponse(HttpStatus.NOT_FOUND, ERROR_CODES.USER_NOT_FOUND)
+  async getUserCondition(
+    @Request() req: any,
+  ): Promise<GetUserConditionResponseDto> {
+    const userId = req.user.sub;
+    return await this.userService.getUserCondition(userId);
   }
 
   /**

--- a/src/api/user/user.module.ts
+++ b/src/api/user/user.module.ts
@@ -14,6 +14,7 @@ import { UserRecentRecipesCustomRepository } from './user-recent-recipes.custom-
 import { UserRecipeBookmarkCustomRepository } from './user-recipe-bookmark.custom-repository';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
+import { UserDailyConditions } from '@/database/entity/user-daily-conditions.entity';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { UserService } from './user.service';
       UserCompletedRecipe,
       Recipe,
       SocialLogin,
+      UserDailyConditions,
     ]),
     AuthModule,
     SocialLoginModule,

--- a/src/api/user/user.service.spec.ts
+++ b/src/api/user/user.service.spec.ts
@@ -8,6 +8,7 @@ import { UserCompletedRecipe } from '@/database/entity/user-completed-recipe.ent
 import { UserRecentRecipes } from '@/database/entity/user-recent-recipes.entity';
 import { UserRecipeBookmark } from '@/database/entity/user-recipe-bookmark.entity';
 import { User } from '@/database/entity/user.entity';
+import { UserDailyConditions } from '@/database/entity/user-daily-conditions.entity';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { SocialLoginService } from '../social-login/social-login.service';
@@ -96,6 +97,10 @@ describe('UserService', () => {
         {
           provide: getRepositoryToken(UserRecentRecipes),
           useValue: mockUserRecentRecipesRepository,
+        },
+        {
+          provide: getRepositoryToken(UserDailyConditions),
+          useValue: {},
         },
         {
           provide: getRepositoryToken(CommonCode),

--- a/src/api/user/user.service.ts
+++ b/src/api/user/user.service.ts
@@ -35,6 +35,7 @@ import {
   TimeSlot,
   UserDailyConditions,
 } from '@/database/entity/user-daily-conditions.entity';
+import { GetUserConditionResponseDto } from './dto/get-user-condition.dto';
 
 @Injectable()
 export class UserService {
@@ -488,6 +489,41 @@ export class UserService {
       };
     } catch (error) {
       this.logger.error('사용자 컨디션 저장 중 에러 발생', error);
+      if (error instanceof CustomException) {
+        throw error;
+      }
+      throw new CustomException(ERROR_CODES.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * 유저의 컨디션을 조회
+   */
+  async getUserCondition(userId: number): Promise<GetUserConditionResponseDto> {
+    try {
+      const user = await this.userRepository.findOne({
+        where: { id: userId },
+      });
+      if (!user) {
+        throw new CustomException(ERROR_CODES.USER_NOT_FOUND);
+      }
+      const cacheKey = `user:${userId}:daily_condition`;
+      const cachedData = await this.cacheService.get(cacheKey);
+      if (!cachedData) {
+        this.logger.log(`User ${userId} condition not found in cache`);
+        return {
+          conditionId: null,
+        };
+      }
+      const parsedData = JSON.parse(cachedData);
+      this.logger.log(
+        `User ${userId} condition retrieved from cache: conditionId=${parsedData.conditionId}`,
+      );
+      return {
+        conditionId: parsedData.conditionId,
+      };
+    } catch (error) {
+      this.logger.error('사용자 컨디션 조회 중 에러 발생', error);
       if (error instanceof CustomException) {
         throw error;
       }

--- a/src/api/user/user.service.ts
+++ b/src/api/user/user.service.ts
@@ -463,8 +463,8 @@ export class UserService {
       this.logger.log(
         `User ${userId} condition saved to cache: conditionId=${conditionId}`,
       );
-      let timeSlot: TimeSlot;
       if (isRecommendationStarted) {
+        let timeSlot: TimeSlot;
         const currentHour = new Date().getHours();
         if (currentHour >= 5 && currentHour < 12) {
           timeSlot = TimeSlot.MORNING;
@@ -480,10 +480,10 @@ export class UserService {
           timeSlot,
         });
         await this.userDailyConditionsRepository.save(userDailyCondition);
+        this.logger.log(
+          `User ${userId} condition saved to database: conditionId=${conditionId}, timeSlot=${timeSlot}`,
+        );
       }
-      this.logger.log(
-        `User ${userId} condition saved to database: conditionId=${conditionId}, timeSlot=${timeSlot}`,
-      );
       return {
         conditionId: conditionId,
       };

--- a/src/api/user/user.service.ts
+++ b/src/api/user/user.service.ts
@@ -515,7 +515,27 @@ export class UserService {
           conditionId: null,
         };
       }
-      const parsedData = JSON.parse(cachedData);
+      let parsedData: { conditionId: number };
+      try {
+        parsedData = JSON.parse(cachedData);
+      } catch {
+        this.logger.warn(
+          `User ${userId} has corrupted cache data, clearing cache`,
+        );
+        await this.cacheService.del(cacheKey);
+        return {
+          conditionId: null,
+        };
+      }
+      if (!parsedData || typeof parsedData.conditionId !== 'number') {
+        this.logger.warn(
+          `User ${userId} has invalid cache data format: ${JSON.stringify(parsedData)}`,
+        );
+        await this.cacheService.del(cacheKey);
+        return {
+          conditionId: null,
+        };
+      }
       this.logger.log(
         `User ${userId} condition retrieved from cache: conditionId=${parsedData.conditionId}`,
       );

--- a/src/api/user/user.service.ts
+++ b/src/api/user/user.service.ts
@@ -27,6 +27,14 @@ import { UserRole } from './enums/role.enum';
 import { UserRecentRecipesCustomRepository } from './user-recent-recipes.custom-repository';
 import { UserRecipeBookmarkCustomRepository } from './user-recipe-bookmark.custom-repository';
 import { GetPendingReviewsResponseDto } from './dto/get-pending-reviews.dto';
+import {
+  SaveUserConditionDto,
+  SaveUserConditionResponseDto,
+} from './dto/save-user-condition.dto';
+import {
+  TimeSlot,
+  UserDailyConditions,
+} from '@/database/entity/user-daily-conditions.entity';
 
 @Injectable()
 export class UserService {
@@ -44,6 +52,8 @@ export class UserService {
     private readonly recipeRepository: Repository<Recipe>,
     @InjectRepository(UserRecentRecipes)
     private readonly userRecentRecipesRepository: Repository<UserRecentRecipes>,
+    @InjectRepository(UserDailyConditions)
+    private readonly userDailyConditionsRepository: Repository<UserDailyConditions>,
     private readonly userRecipeBookmarkCustomRepository: UserRecipeBookmarkCustomRepository,
     private readonly userRecentRecipesCustomRepository: UserRecentRecipesCustomRepository,
     @InjectRepository(CommonCode)
@@ -425,5 +435,63 @@ export class UserService {
       totalCount: completedRecipes.length,
       completedRecipeIds,
     };
+  }
+
+  /**
+   * 유저의 컨디션을 저장
+   */
+  async saveUserCondition(
+    userId: number,
+    dto: SaveUserConditionDto,
+  ): Promise<SaveUserConditionResponseDto> {
+    try {
+      const user = await this.userRepository.findOne({
+        where: { id: userId },
+      });
+      if (!user) {
+        throw new CustomException(ERROR_CODES.USER_NOT_FOUND);
+      }
+      const { conditionId, isRecommendationStarted } = dto;
+      const cacheKey = `user:${userId}:daily_condition`;
+      const ttl = 24 * 60 * 60 * 1000; // 24시간 (밀리초)
+      const cachedData = {
+        conditionId,
+        savedAt: new Date().toISOString(),
+      };
+      await this.cacheService.set(cacheKey, JSON.stringify(cachedData), ttl);
+      this.logger.log(
+        `User ${userId} condition saved to cache: conditionId=${conditionId}`,
+      );
+      let timeSlot: TimeSlot;
+      if (isRecommendationStarted) {
+        const currentHour = new Date().getHours();
+        if (currentHour >= 5 && currentHour < 12) {
+          timeSlot = TimeSlot.MORNING;
+        } else if (currentHour >= 12 && currentHour < 18) {
+          timeSlot = TimeSlot.LUNCH;
+        } else {
+          timeSlot = TimeSlot.DINNER;
+        }
+        const userDailyCondition = this.userDailyConditionsRepository.create({
+          userId,
+          conditionId,
+          date: new Date(),
+          timeSlot,
+        });
+        await this.userDailyConditionsRepository.save(userDailyCondition);
+      }
+      this.logger.log(
+        `User ${userId} condition saved to database: conditionId=${conditionId}, timeSlot=${timeSlot}`,
+      );
+      return {
+        conditionId: conditionId,
+      };
+    } catch (error) {
+      this.logger.error('사용자 컨디션 저장 중 에러 발생', error);
+      if (error instanceof CustomException) {
+        throw error;
+      }
+      throw new CustomException(ERROR_CODES.INTERNAL_SERVER_ERROR);
+    }
   }
 }


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 유저 컨디션 관련 기능 추가

### ✨ 변경 내용  
---  
- 유저 컨디션 저장 기능 추가 (기본적으로 캐시에 TTL 24시간으로 저장하고, 만약 추천까지 완료된 경우에는 DB에 추가 저장)
- 유저 컨디션 조회 기능 추가 (캐시에서 조회)

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 일일 컨디션 저장 API 추가: 클라이언트에서 컨디션 ID와 추천 시작 여부 전송 가능.
  * 사용자 일일 컨디션 조회 API 추가: 저장된 컨디션 ID 조회 응답 제공.
  * 컨디션 정보 캐시 적용(24시간 TTL) 및 필요 시 일별 기록 영속화로 시간대별 보존.

* **테스트**
  * 관련 테스트 모듈에 일별 컨디션 저장소 모킹 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->