### PR TITLE
feat: 레시피 목록 응답에 북마크 여부 필드 추가

### DIFF
--- a/src/api/user-recipe-archive/user-recipe-archive.service.spec.ts
+++ b/src/api/user-recipe-archive/user-recipe-archive.service.spec.ts
@@ -177,6 +177,7 @@ describe('UserRecipeArchiveService', () => {
             isCompleted: true,
             isReviewed: false,
             createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            isBookmarked: true,
           },
         ],
         total: 1,
@@ -257,6 +258,62 @@ describe('UserRecipeArchiveService', () => {
         userId,
         recipeId,
       );
+    });
+  });
+
+  describe('getRecentRecipes', () => {
+    const userId = 1;
+    const query = { page: 1, limit: 10 };
+
+    it('성공적으로 최근 본 레시피 목록을 조회해야 함', async () => {
+      // Given
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      const mockRecentRecipes = {
+        items: [
+          {
+            id: 1,
+            userId: 1,
+            recipeId: 1,
+            recipeTitle: '최근 본 김치찌개',
+            recipeDescription: '매콤하고 시원한 김치찌개',
+            recipeImages: ['https://example.com/kimchi-recent.jpg'],
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            isBookmarked: false,
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+      };
+      mockUserRecentRecipesCustomRepository.findRecentRecipesWithRecipeByUserIdPaginated.mockResolvedValue(
+        mockRecentRecipes,
+      );
+
+      // When
+      const result = await service.getRecentRecipes(userId, query);
+
+      // Then
+      expect(result).toEqual(mockRecentRecipes);
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
+      expect(
+        mockUserRecentRecipesCustomRepository.findRecentRecipesWithRecipeByUserIdPaginated,
+      ).toHaveBeenCalledWith(userId, 1, 10);
+    });
+
+    it('사용자가 존재하지 않으면 USER_NOT_FOUND 예외를 발생시켜야 함', async () => {
+      // Given
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      // When & Then
+      await expect(service.getRecentRecipes(userId, query)).rejects.toThrow(
+        new CustomException(ERROR_CODES.USER_NOT_FOUND),
+      );
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
     });
   });
 

--- a/src/api/user/dto/completed-recipe-with-recipe.dto.ts
+++ b/src/api/user/dto/completed-recipe-with-recipe.dto.ts
@@ -39,4 +39,10 @@ export class CompletedRecipeWithRecipeDto {
     example: '2024-01-01T00:00:00.000Z',
   })
   createdAt: Date;
+
+  @ApiProperty({
+    description: '북마크 여부',
+    example: true,
+  })
+  isBookmarked: boolean;
 }

--- a/src/api/user/dto/recent-recipe-with-recipe.dto.ts
+++ b/src/api/user/dto/recent-recipe-with-recipe.dto.ts
@@ -27,4 +27,10 @@ export class RecentRecipeWithRecipeDto {
     example: '2024-01-01T00:00:00.000Z',
   })
   createdAt: Date;
+
+  @ApiProperty({
+    description: '북마크 여부',
+    example: true,
+  })
+  isBookmarked: boolean;
 }

--- a/src/api/user/user-completed-recipe.custom-repository.ts
+++ b/src/api/user/user-completed-recipe.custom-repository.ts
@@ -31,10 +31,16 @@ export class UserCompletedRecipeCustomRepository extends Repository<any> {
         'recipe.title as recipe_title',
         'recipe.description as recipe_description',
         'image.image_url as recipe_image',
+        'CASE WHEN bookmark.id IS NOT NULL THEN 1 ELSE 0 END as is_bookmarked',
       ])
       .from('user_completed_recipes', 'completed')
       .leftJoin('recipes', 'recipe', 'completed.recipe_id = recipe.id')
       .leftJoin('recipe_images', 'image', 'recipe.id = image.recipe_id')
+      .leftJoin(
+        'user_recipe_bookmarks',
+        'bookmark',
+        'completed.user_id = bookmark.user_id AND completed.recipe_id = bookmark.recipe_id',
+      )
       .where('completed.user_id = :userId', { userId })
       .andWhere('completed.is_completed = :isCompleted', { isCompleted: true })
       .orderBy('completed.created_at', 'DESC');
@@ -54,6 +60,7 @@ export class UserCompletedRecipeCustomRepository extends Repository<any> {
           isCompleted: row.completed_is_completed,
           isReviewed: row.completed_is_reviewed,
           createdAt: row.completed_created_at,
+          isBookmarked: Boolean(row.is_bookmarked),
         });
       } else {
         const existing = map.get(row.completed_id)!;

--- a/src/api/user/user-recent-recipes.custom-repository.ts
+++ b/src/api/user/user-recent-recipes.custom-repository.ts
@@ -29,10 +29,16 @@ export class UserRecentRecipesCustomRepository extends Repository<any> {
         'recipe.title as recipe_title',
         'recipe.description as recipe_description',
         'image.image_url as recipe_image',
+        'CASE WHEN bookmark.id IS NOT NULL THEN 1 ELSE 0 END as is_bookmarked',
       ])
       .from('user_recent_recipes', 'recent')
       .leftJoin('recipes', 'recipe', 'recent.recipe_id = recipe.id')
       .leftJoin('recipe_images', 'image', 'recipe.id = image.recipe_id')
+      .leftJoin(
+        'user_recipe_bookmarks',
+        'bookmark',
+        'recent.user_id = bookmark.user_id AND recent.recipe_id = bookmark.recipe_id',
+      )
       .where('recent.user_id = :userId', { userId })
       .orderBy('recent.created_at', 'DESC');
 
@@ -49,6 +55,7 @@ export class UserRecentRecipesCustomRepository extends Repository<any> {
           recipeDescription: row.recipe_description,
           recipeImages: row.recipe_image ? [row.recipe_image] : [],
           createdAt: row.recent_created_at,
+          isBookmarked: Boolean(row.is_bookmarked),
         });
       } else {
         const existing = map.get(row.recent_id)!;

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -145,7 +145,9 @@ describe('UserController (E2E)', () => {
         expect(completedRecipe).toHaveProperty('isCompleted');
         expect(completedRecipe).toHaveProperty('isReviewed');
         expect(completedRecipe).toHaveProperty('createdAt');
+        expect(completedRecipe).toHaveProperty('isBookmarked');
         expect(completedRecipe.isCompleted).toBe(true);
+        expect(typeof completedRecipe.isBookmarked).toBe('boolean');
         expect(Array.isArray(completedRecipe.recipeImages)).toBe(true);
       }
     });
@@ -155,6 +157,58 @@ describe('UserController (E2E)', () => {
         app,
         'get',
         '/v1/users/recipes/completed?page=1&limit=2',
+      );
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.data).toHaveProperty('items');
+      expect(response.body.data).toHaveProperty('total');
+      expect(response.body.data).toHaveProperty('page');
+      expect(response.body.data).toHaveProperty('limit');
+      expect(response.body.data).toHaveProperty('totalPages');
+      expect(response.body.data.page).toBe(1);
+      expect(response.body.data.limit).toBe(2);
+      expect(Array.isArray(response.body.data.items)).toBe(true);
+      expect(response.body.data.items.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('최근 본 레시피 조회 플로우', () => {
+    it(`${TEST_TAGS.AUTHENTICATED} 최근 본 레시피 목록 조회 - /users/recipes/recent (GET)`, async () => {
+      const response = await authenticatedRequest(
+        app,
+        'get',
+        '/v1/users/recipes/recent',
+      );
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.data).toHaveProperty('items');
+      expect(response.body.data).toHaveProperty('total');
+      expect(response.body.data).toHaveProperty('page');
+      expect(response.body.data).toHaveProperty('limit');
+      expect(response.body.data).toHaveProperty('totalPages');
+      expect(Array.isArray(response.body.data.items)).toBe(true);
+
+      // 최근 본 레시피 데이터 구조 검증
+      if (response.body.data.items.length > 0) {
+        const recentRecipe = response.body.data.items[0];
+        expect(recentRecipe).toHaveProperty('id');
+        expect(recentRecipe).toHaveProperty('userId');
+        expect(recentRecipe).toHaveProperty('recipeId');
+        expect(recentRecipe).toHaveProperty('recipeTitle');
+        expect(recentRecipe).toHaveProperty('recipeDescription');
+        expect(recentRecipe).toHaveProperty('recipeImages');
+        expect(recentRecipe).toHaveProperty('createdAt');
+        expect(recentRecipe).toHaveProperty('isBookmarked');
+        expect(typeof recentRecipe.isBookmarked).toBe('boolean');
+        expect(Array.isArray(recentRecipe.recipeImages)).toBe(true);
+      }
+    });
+
+    it(`${TEST_TAGS.AUTHENTICATED} 최근 본 레시피 목록 조회 (페이지네이션) - /users/recipes/recent?page=1&limit=2 (GET)`, async () => {
+      const response = await authenticatedRequest(
+        app,
+        'get',
+        '/v1/users/recipes/recent?page=1&limit=2',
       );
 
       expect(response.status).toBe(HttpStatus.OK);

--- a/test/mocks/user.mock.ts
+++ b/test/mocks/user.mock.ts
@@ -42,6 +42,7 @@ const mockUserRecipeArchiveService = {
         recipeDescription: '매콤하고 시원한 김치찌개',
         recipeImages: ['https://example.com/kimchi.jpg'],
         createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        isBookmarked: true,
       },
       {
         id: 2,
@@ -51,6 +52,7 @@ const mockUserRecipeArchiveService = {
         recipeDescription: '집에서 쉽게 만들 수 있는 계란볶음밥',
         recipeImages: ['https://example.com/egg-rice.jpg'],
         createdAt: new Date('2024-01-02T00:00:00.000Z'),
+        isBookmarked: true,
       },
       {
         id: 3,
@@ -60,6 +62,7 @@ const mockUserRecipeArchiveService = {
         recipeDescription: '구수하고 부드러운 된장찌개',
         recipeImages: ['https://example.com/doenjang.jpg'],
         createdAt: new Date('2024-01-03T00:00:00.000Z'),
+        isBookmarked: true,
       },
     ];
 
@@ -120,6 +123,7 @@ const mockUserRecipeArchiveService = {
         isCompleted: true,
         isReviewed: false,
         createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        isBookmarked: true,
       },
       {
         id: 2,
@@ -131,6 +135,7 @@ const mockUserRecipeArchiveService = {
         isCompleted: true,
         isReviewed: true,
         createdAt: new Date('2024-01-02T00:00:00.000Z'),
+        isBookmarked: false,
       },
       {
         id: 3,
@@ -142,6 +147,7 @@ const mockUserRecipeArchiveService = {
         isCompleted: true,
         isReviewed: false,
         createdAt: new Date('2024-01-03T00:00:00.000Z'),
+        isBookmarked: true,
       },
     ];
 
@@ -151,6 +157,60 @@ const mockUserRecipeArchiveService = {
     const startIndex = (pageNum - 1) * limitNum;
     const endIndex = startIndex + limitNum;
     const items = mockCompletedRecipes.slice(startIndex, endIndex);
+
+    return {
+      items,
+      total,
+      page: pageNum,
+      limit: limitNum,
+      totalPages,
+    };
+  },
+  getRecentRecipes: async (_userId: number, query: any) => {
+    // Mock 데이터: 페이지네이션 응답 구조와 동일하게
+    const { page = 1, limit = 10 } = query;
+    const pageNum = parseInt(page.toString(), 10);
+    const limitNum = parseInt(limit.toString(), 10);
+
+    const mockRecentRecipes = [
+      {
+        id: 1,
+        userId: _userId,
+        recipeId: 1,
+        recipeTitle: '최근 본 김치찌개',
+        recipeDescription: '매콤하고 시원한 김치찌개',
+        recipeImages: ['https://example.com/kimchi-recent.jpg'],
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        isBookmarked: false,
+      },
+      {
+        id: 2,
+        userId: _userId,
+        recipeId: 2,
+        recipeTitle: '최근 본 계란볶음밥',
+        recipeDescription: '집에서 쉽게 만들 수 있는 계란볶음밥',
+        recipeImages: ['https://example.com/egg-rice-recent.jpg'],
+        createdAt: new Date('2024-01-02T00:00:00.000Z'),
+        isBookmarked: true,
+      },
+      {
+        id: 3,
+        userId: _userId,
+        recipeId: 3,
+        recipeTitle: '최근 본 된장찌개',
+        recipeDescription: '구수하고 부드러운 된장찌개',
+        recipeImages: ['https://example.com/doenjang-recent.jpg'],
+        createdAt: new Date('2024-01-03T00:00:00.000Z'),
+        isBookmarked: false,
+      },
+    ];
+
+    // 페이지네이션 계산
+    const total = mockRecentRecipes.length;
+    const totalPages = Math.ceil(total / limitNum);
+    const startIndex = (pageNum - 1) * limitNum;
+    const endIndex = startIndex + limitNum;
+    const items = mockRecentRecipes.slice(startIndex, endIndex);
 
     return {
       items,


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 최근 본 레시피와 완료한 레시피 조회 시 북마크 여부 포함
- 관련 테스트 코드 업데이트

### ✨ 변경 내용  
---  
- [ ] (변경된 사항 요약) 
- [ ] (새로 추가된 기능이나 수정된 내용)  
- [ ] (리팩토링 및 코드 개선 사항)  

### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 완료된 레시피에 북마크 상태 표시 추가
  * 최근 본 레시피 조회 시 북마크 여부 정보 포함
  * 최근 본 레시피 페이지네이션 조회 기능 추가

* **테스트**
  * 북마크 상태 필드 검증 테스트 추가
  * 최근 본 레시피 조회 엔드포인트 테스트 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->