### PR TITLE
fix: make saveUnavailableIngredients transactional and fix user_id bi…

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,13 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="877a34dc-a287-45b7-af8a-51998ab368f4" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/api/login/dto/google-login.response.dto.ts" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/common/constants/google-api.constants.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/api/login/login.controller.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/api/login/login.controller.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/api/login/login.service.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/api/login/login.service.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/common/constants/error-codes.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/common/constants/error-codes.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/common/swagger.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/common/swagger.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/api/user/user.service.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/api/user/user.service.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -30,7 +24,7 @@
   </component>
   <component name="PropertiesComponent"><![CDATA[{
   "keyToString": {
-    "git-widget-placeholder": "feature/add-new-google-login",
+    "git-widget-placeholder": "feature/save-unavailable-ingredients",
     "node.js.selected.package.tslint": "(autodetect)",
     "prettierjs.PrettierConfiguration.Package": "/Users/sangwonlee/Projects/recipot-add-google-login/recipot-backend/node_modules/prettier",
     "ts.external.directory.path": "/Users/sangwonlee/Projects/recipot-add-google-login/recipot-backend/node_modules/typescript/lib"

--- a/src/api/user/user.service.ts
+++ b/src/api/user/user.service.ts
@@ -42,6 +42,7 @@ import { UserDto } from './dto/user.dto';
 import { UserRole } from './enums/role.enum';
 import { UserRecentRecipesCustomRepository } from './user-recent-recipes.custom-repository';
 import { UserRecipeBookmarkCustomRepository } from './user-recipe-bookmark.custom-repository';
+import { UserUnavailableIngredient } from '@/database/entity/user-unavailable-ingredient.entity';
 
 @Injectable()
 export class UserService {
@@ -495,31 +496,41 @@ export class UserService {
     userId: number,
     dto: SaveUnavailableIngredientsDto,
   ): Promise<SaveUnavailableIngredientsResponseDto> {
-    // Verify user exists
+    // 1) Verify user exists
     const user = await this.userRepository.findOne({ where: { id: userId } });
     if (!user) throw new CustomException(ERROR_CODES.USER_NOT_FOUND);
 
-    // Deduplicate & coerce to positive integers
+    // 2) Deduplicate & coerce to positive integers
     const ids = Array.from(new Set(dto.ingredientIds ?? []))
       .map(Number)
       .filter((n) => Number.isInteger(n) && n > 0);
 
-    // Delete all for this user
-    await this.userRepository.query(
-      'DELETE FROM user_unavailable_ingredients WHERE user_id = ?',
-      [userId],
-    );
+    // 3) Atomic replace inside a transaction
+    await this.userRepository.manager.transaction(async (m) => {
+      // delete old rows
+      await m
+        .createQueryBuilder()
+        .delete()
+        .from(UserUnavailableIngredient) // entity
+        .where('user_id = :userId', { userId }) // raw column name is fine here
+        .execute();
 
-    if (ids.length > 0) {
-      // Build VALUES (?, ?), (?, ?), ... repeating userId for each row
-      const values = ids.map(() => '(?, ?)').join(', ');
-      const params = ids.flatMap((id) => [userId, id]);
-
-      await this.userRepository.query(
-        `INSERT INTO user_unavailable_ingredients (user_id, ingredient_id) VALUES ${values}`,
-        params,
-      );
-    }
+      // bulk insert new rows (if any)
+      if (ids.length > 0) {
+        await m
+          .createQueryBuilder()
+          .insert()
+          .into(UserUnavailableIngredient) // entity
+          .values(
+            ids.map((ingredientId) => ({
+              userId,
+              ingredientId,
+            })),
+          )
+          .orIgnore() // MySQL/MariaDB duplicate-safe (requires UNIQUE(user_id, ingredient_id))
+          .execute();
+      }
+    });
 
     return { savedCount: ids.length };
   }


### PR DESCRIPTION


### 🚀 Pull Request  
---  
사용자 비활성 재료 저장 로직 개선 및 트랜잭션 적용

### ✨ 변경 내용  
	•	saveUnavailableIngredients 메서드에 트랜잭션 적용
	•	DELETE → INSERT 과정이 하나의 트랜잭션 안에서 처리되도록 변경
	•	데이터 정합성 보장 및 중간 실패 시 롤백 가능
	•	TypeORM QueryBuilder 기반으로 쿼리 리팩토링
	•	기존의 raw query 제거 (DELETE FROM ..., INSERT INTO ...)
	•	엔티티 프로퍼티(userId, ingredientId) 기반 값 매핑으로 MySQL 에러(Field 'user_id' doesn't have a default value) 해결
	•	orIgnore() 추가하여 중복 키 예외 방지 (UNIQUE(user_id, ingredient_id) 인덱스 대응)

⸻

### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이 업데이트는 주로 내부 코드 개선 사항을 포함하고 있으며, 최종 사용자에게 직접 보이는 새로운 기능이나 버그 수정은 없습니다.

* **개선사항**
  * 데이터 저장 프로세스의 안정성 및 신뢰성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->