### PR TITLE
feat: 카카오 로그인 토큰 방식 수정(기존: 쿠키 설정, 변경: 바디에 반환)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@nestjs/terminus": "^11.0.0",
         "@nestjs/typeorm": "^11.0.0",
         "@types/multer": "^2.0.0",
+        "@types/uuid": "^10.0.0",
         "axios": "^1.11.0",
         "bcrypt": "^5.1.1",
         "cache-manager": "^5.2.3",
@@ -46,6 +47,7 @@
         "typeorm": "^0.3.20",
         "typeorm-extension": "^3.7.1",
         "typeorm-transactional": "^0.5.0",
+        "uuid": "^8.3.2",
         "winston": "^3.17.0"
       },
       "devDependencies": {
@@ -475,6 +477,25 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -3139,6 +3160,25 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/core/node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT"
+    },
+    "node_modules/@smithy/core/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "4.0.7",
       "license": "Apache-2.0",
@@ -3344,6 +3384,25 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT"
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@smithy/middleware-serde": {
@@ -3992,7 +4051,9 @@
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.8",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@types/validator": {
@@ -11701,11 +11762,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "mariadb": "^3.4.5",
         "multer": "^2.0.2",
         "mysql2": "^3.12.0",
+        "nanoid": "^5.1.6",
         "nest-winston": "^1.10.2",
         "nestjs-typeorm-paginate": "^4.0.4",
         "passport": "^0.7.0",
@@ -9220,6 +9221,24 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "mariadb": "^3.4.5",
     "multer": "^2.0.2",
     "mysql2": "^3.12.0",
+    "nanoid": "^5.1.6",
     "nest-winston": "^1.10.2",
     "nestjs-typeorm-paginate": "^4.0.4",
     "passport": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/typeorm": "^11.0.0",
     "@types/multer": "^2.0.0",
+    "@types/uuid": "^10.0.0",
     "axios": "^1.11.0",
     "bcrypt": "^5.1.1",
     "cache-manager": "^5.2.3",
@@ -67,6 +68,7 @@
     "typeorm": "^0.3.20",
     "typeorm-extension": "^3.7.1",
     "typeorm-transactional": "^0.5.0",
+    "uuid": "^8.3.2",
     "winston": "^3.17.0"
   },
   "devDependencies": {

--- a/src/api/login/login.controller.ts
+++ b/src/api/login/login.controller.ts
@@ -36,13 +36,10 @@ export class LoginController {
     required: true,
     description: '카카오에서 받은 인가 코드',
   })
-  @ApiSuccessResponse('카카오 로그인 성공', {
-    type: 'object',
-    properties: {
-      userId: { type: 'number', example: 1 },
-    },
-  })
-  async kakaoLoginCallback(@Query('code') code: string) {
+  @ApiSuccessResponse('카카오 로그인 성공', LoginCallbackResponseDto)
+  async kakaoLoginCallback(
+    @Query('code') code: string,
+  ): Promise<LoginCallbackResponseDto> {
     return await this.loginService.processKakaoLogin(code);
   }
 

--- a/src/api/login/login.controller.ts
+++ b/src/api/login/login.controller.ts
@@ -2,8 +2,9 @@ import { Public } from '@/api/auth/decorators/auth.decorators';
 import { GoogleLoginResponseDto } from '@/api/login/dto/google-login.response.dto';
 import { LoginCallbackResponseDto } from '@/api/login/dto/login-callback-response.dto';
 import { ApiSuccessResponse } from '@/common/decorators/api-success-response.decorator';
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, Res, Param } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
 import { LoginService } from './login.service';
 
 @ApiTags('로그인')
@@ -36,11 +37,30 @@ export class LoginController {
     required: true,
     description: '카카오에서 받은 인가 코드',
   })
-  @ApiSuccessResponse('카카오 로그인 성공', LoginCallbackResponseDto)
+  @ApiSuccessResponse('카카오 로그인 성공')
   async kakaoLoginCallback(
     @Query('code') code: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const result = await this.loginService.processKakaoLogin(code);
+
+    const redirectUrl = new URL(process.env.FRONTEND_LOGIN_CALLBACK_URL);
+    redirectUrl.searchParams.set('userId', String(result.userId));
+
+    return res.redirect(302, redirectUrl.toString());
+  }
+
+  @Get('session/:userId')
+  @Public()
+  @ApiOperation({
+    summary: '로그인 세션 조회',
+    description: '캐시된 토큰 정보를 조회합니다. (1회용)',
+  })
+  @ApiSuccessResponse('로그인 세션 조회 성공', LoginCallbackResponseDto)
+  async getLoginSession(
+    @Param('userId') userId: string,
   ): Promise<LoginCallbackResponseDto> {
-    return await this.loginService.processKakaoLogin(code);
+    return await this.loginService.retrieveLoginSession(parseInt(userId));
   }
 
   // ApiSuccessResponse 사용 시 Swagger 번들에서

--- a/src/api/login/login.controller.ts
+++ b/src/api/login/login.controller.ts
@@ -42,15 +42,15 @@ export class LoginController {
     @Query('code') code: string,
     @Res() res: Response,
   ): Promise<void> {
-    const result = await this.loginService.processKakaoLogin(code);
+    const sessionKey = await this.loginService.processKakaoLogin(code);
 
     const redirectUrl = new URL(process.env.FRONTEND_LOGIN_CALLBACK_URL);
-    redirectUrl.searchParams.set('userId', String(result.userId));
+    redirectUrl.searchParams.set('sessionKey', sessionKey);
 
     return res.redirect(302, redirectUrl.toString());
   }
 
-  @Get('session/:userId')
+  @Get('session/:sessionKey')
   @Public()
   @ApiOperation({
     summary: '로그인 세션 조회',
@@ -58,9 +58,9 @@ export class LoginController {
   })
   @ApiSuccessResponse('로그인 세션 조회 성공', LoginCallbackResponseDto)
   async getLoginSession(
-    @Param('userId') userId: string,
+    @Param('sessionKey') sessionKey: string,
   ): Promise<LoginCallbackResponseDto> {
-    return await this.loginService.retrieveLoginSession(parseInt(userId));
+    return await this.loginService.retrieveLoginSession(sessionKey);
   }
 
   // ApiSuccessResponse 사용 시 Swagger 번들에서

--- a/src/api/login/login.controller.ts
+++ b/src/api/login/login.controller.ts
@@ -2,9 +2,8 @@ import { Public } from '@/api/auth/decorators/auth.decorators';
 import { GoogleLoginResponseDto } from '@/api/login/dto/google-login.response.dto';
 import { LoginCallbackResponseDto } from '@/api/login/dto/login-callback-response.dto';
 import { ApiSuccessResponse } from '@/common/decorators/api-success-response.decorator';
-import { Controller, Get, Query, Res } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
-import { Response } from 'express';
 import { LoginService } from './login.service';
 
 @ApiTags('로그인')
@@ -43,13 +42,8 @@ export class LoginController {
       userId: { type: 'number', example: 1 },
     },
   })
-  async kakaoLoginCallback(@Query('code') code: string, @Res() res: Response) {
-    const result = await this.loginService.processKakaoLogin(code, res);
-
-    const redirectUrl = new URL(process.env.FRONTEND_LOGIN_CALLBACK_URL);
-    redirectUrl.searchParams.set('userId', String(result.userId));
-
-    return res.redirect(302, redirectUrl.toString());
+  async kakaoLoginCallback(@Query('code') code: string) {
+    return await this.loginService.processKakaoLogin(code);
   }
 
   // ApiSuccessResponse 사용 시 Swagger 번들에서

--- a/src/api/login/login.service.ts
+++ b/src/api/login/login.service.ts
@@ -15,6 +15,7 @@ import { CustomException } from '@/common/exceptions/custom-exception';
 import { CacheService } from '@/common/cache/cache.service';
 import { Injectable, Logger } from '@nestjs/common';
 import axios from 'axios';
+import { v4 as uuid } from 'uuid';
 import * as qs from 'qs';
 import { LoginCallbackResponseDto } from './dto/login-callback-response.dto';
 
@@ -46,7 +47,7 @@ export class LoginService {
   /**
    * 카카오 로그인을 처리합니다.
    */
-  async processKakaoLogin(code: string): Promise<LoginCallbackResponseDto> {
+  async processKakaoLogin(code: string): Promise<string> {
     // 1. 인가 코드로 액세스 토큰 요청
     const tokenResponse = await this.getKakaoAccessToken(code);
 
@@ -104,21 +105,22 @@ export class LoginService {
       refreshExpiresAt,
     };
 
-    // 5. 토큰을 캐시에 저장 (유저 ID 기반, 5분 TTL)
-    await this.cacheLoginSession(user.id, tokenData, 300);
+    // 5. 세션 키 생성 (순수 UUID) 및 캐시 저장 (10초 TTL)
+    const sessionKey = uuid();
+    await this.cacheLoginSession(sessionKey, tokenData, 10);
 
-    return tokenData;
+    return sessionKey;
   }
 
   /**
-   * 로그인 토큰을 캐시에 저장합니다. (유저 ID 기반)
+   * 로그인 토큰을 캐시에 저장합니다. (세션 키 기반)
    */
   private async cacheLoginSession(
-    userId: number,
+    sessionKey: string,
     tokenData: LoginCallbackResponseDto,
     ttlSeconds: number,
   ): Promise<void> {
-    const cacheKey = `login:session:${userId}`;
+    const cacheKey = `login:session:${sessionKey}`;
 
     await this.cacheService.set(
       cacheKey,
@@ -127,7 +129,7 @@ export class LoginService {
     );
 
     this.logger.debug(
-      `Login session cached for userId: ${userId} (TTL: ${ttlSeconds}s)`,
+      `Login session cached: ${sessionKey} (TTL: ${ttlSeconds}s)`,
     );
   }
 
@@ -135,9 +137,9 @@ export class LoginService {
    * 캐시된 로그인 토큰을 조회합니다. (1회용 - 조회 후 삭제)
    */
   async retrieveLoginSession(
-    userId: number,
+    sessionKey: string,
   ): Promise<LoginCallbackResponseDto> {
-    const cacheKey = `login:session:${userId}`;
+    const cacheKey = `login:session:${sessionKey}`;
 
     const cachedData = await this.cacheService.get(cacheKey);
 
@@ -148,9 +150,7 @@ export class LoginService {
     // 조회 후 즉시 삭제 (1회용)
     await this.cacheService.del(cacheKey);
 
-    this.logger.debug(
-      `Login session retrieved and deleted for userId: ${userId}`,
-    );
+    this.logger.debug(`Login session retrieved and deleted: ${sessionKey}`);
 
     return JSON.parse(cachedData) as LoginCallbackResponseDto;
   }

--- a/src/api/login/login.service.ts
+++ b/src/api/login/login.service.ts
@@ -14,7 +14,6 @@ import {
 import { CustomException } from '@/common/exceptions/custom-exception';
 import { Injectable, Logger } from '@nestjs/common';
 import axios from 'axios';
-import { Response } from 'express';
 import * as qs from 'qs';
 
 @Injectable()
@@ -44,7 +43,7 @@ export class LoginService {
   /**
    * 카카오 로그인을 처리합니다.
    */
-  async processKakaoLogin(code: string, res?: Response) {
+  async processKakaoLogin(code: string) {
     // 1. 인가 코드로 액세스 토큰 요청
     const tokenResponse = await this.getKakaoAccessToken(code);
 
@@ -94,31 +93,12 @@ export class LoginService {
     const { accessToken, refreshToken, accessExpiresAt, refreshExpiresAt } =
       await this.authService.generateSocialLoginTokens(user.id, user.role);
 
-    if (res) {
-      const isProduction = process.env.NODE_ENV === 'production';
-      const domain = process.env.BASE_DOMAIN;
-
-      res.cookie('accessToken', accessToken, {
-        httpOnly: true,
-        secure: isProduction,
-        sameSite: isProduction ? 'none' : 'lax',
-        path: '/',
-        domain: isProduction ? domain : undefined,
-        expires: new Date(accessExpiresAt as unknown as string),
-      });
-
-      res.cookie('refreshToken', refreshToken, {
-        httpOnly: true,
-        secure: isProduction,
-        sameSite: isProduction ? 'none' : 'lax',
-        path: '/',
-        domain: isProduction ? domain : undefined,
-        expires: new Date(refreshExpiresAt as unknown as string),
-      });
-    }
-
     return {
       userId: user.id,
+      accessToken,
+      accessExpiresAt,
+      refreshToken,
+      refreshExpiresAt,
     };
   }
 

--- a/src/api/login/login.service.ts
+++ b/src/api/login/login.service.ts
@@ -12,6 +12,7 @@ import {
   KAKAO_API_URLS,
 } from '@/common/constants/kakao-api.constants';
 import { CustomException } from '@/common/exceptions/custom-exception';
+import { CacheService } from '@/common/cache/cache.service';
 import { Injectable, Logger } from '@nestjs/common';
 import axios from 'axios';
 import * as qs from 'qs';
@@ -25,6 +26,7 @@ export class LoginService {
     private readonly authService: AuthService,
     private readonly socialLoginService: SocialLoginService,
     private readonly userService: UserService,
+    private readonly cacheService: CacheService,
   ) {}
 
   /**
@@ -94,13 +96,63 @@ export class LoginService {
     const { accessToken, refreshToken, accessExpiresAt, refreshExpiresAt } =
       await this.authService.generateSocialLoginTokens(user.id, user.role);
 
-    return {
+    const tokenData: LoginCallbackResponseDto = {
       userId: user.id,
       accessToken,
       accessExpiresAt,
       refreshToken,
       refreshExpiresAt,
     };
+
+    // 5. 토큰을 캐시에 저장 (유저 ID 기반, 5분 TTL)
+    await this.cacheLoginSession(user.id, tokenData, 300);
+
+    return tokenData;
+  }
+
+  /**
+   * 로그인 토큰을 캐시에 저장합니다. (유저 ID 기반)
+   */
+  private async cacheLoginSession(
+    userId: number,
+    tokenData: LoginCallbackResponseDto,
+    ttlSeconds: number,
+  ): Promise<void> {
+    const cacheKey = `login:session:${userId}`;
+
+    await this.cacheService.set(
+      cacheKey,
+      JSON.stringify(tokenData),
+      ttlSeconds * 1000,
+    );
+
+    this.logger.debug(
+      `Login session cached for userId: ${userId} (TTL: ${ttlSeconds}s)`,
+    );
+  }
+
+  /**
+   * 캐시된 로그인 토큰을 조회합니다. (1회용 - 조회 후 삭제)
+   */
+  async retrieveLoginSession(
+    userId: number,
+  ): Promise<LoginCallbackResponseDto> {
+    const cacheKey = `login:session:${userId}`;
+
+    const cachedData = await this.cacheService.get(cacheKey);
+
+    if (!cachedData) {
+      throw new CustomException(ERROR_CODES.LOGIN_SESSION_NOT_FOUND);
+    }
+
+    // 조회 후 즉시 삭제 (1회용)
+    await this.cacheService.del(cacheKey);
+
+    this.logger.debug(
+      `Login session retrieved and deleted for userId: ${userId}`,
+    );
+
+    return JSON.parse(cachedData) as LoginCallbackResponseDto;
   }
 
   /**

--- a/src/api/login/login.service.ts
+++ b/src/api/login/login.service.ts
@@ -15,6 +15,7 @@ import { CustomException } from '@/common/exceptions/custom-exception';
 import { Injectable, Logger } from '@nestjs/common';
 import axios from 'axios';
 import * as qs from 'qs';
+import { LoginCallbackResponseDto } from './dto/login-callback-response.dto';
 
 @Injectable()
 export class LoginService {
@@ -43,7 +44,7 @@ export class LoginService {
   /**
    * 카카오 로그인을 처리합니다.
    */
-  async processKakaoLogin(code: string) {
+  async processKakaoLogin(code: string): Promise<LoginCallbackResponseDto> {
     // 1. 인가 코드로 액세스 토큰 요청
     const tokenResponse = await this.getKakaoAccessToken(code);
 

--- a/src/common/constants/error-codes.ts
+++ b/src/common/constants/error-codes.ts
@@ -91,4 +91,8 @@ export const ERROR_CODES = {
   LOGOUT_FAILED: { code: 'E2101', message: '로그아웃 처리 중 오류가 발생했습니다.' },
   REFRESH_REVOKE_FAILED: { code: 'E2102', message: '리프레시 토큰을 무효화하지 못했습니다.' },
   ACCESS_BLACKLIST_FAILED: { code: 'E2103', message: '액세스 토큰 블랙리스트 처리에 실패했습니다.' },
+
+  // 로그인 세션 관련
+  LOGIN_SESSION_NOT_FOUND: { code: 'E2104', message: '로그인 세션을 찾을 수 없습니다. 다시 로그인해주세요.' },
+  LOGIN_SESSION_EXPIRED: { code: 'E2105', message: '로그인 세션이 만료되었습니다. 다시 로그인해주세요.' },
 };


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 카카오 로그인 토큰 방식 수정(기존: 쿠키 설정, 변경: 바디에 반환)

### ✨ 변경 내용  
---  
- 카카오 로그인 방식 수정 (기존: 쿠키 설정, 변경: 바디에 반환)

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 카카오 로그인 콜백이 세션 키 기반 리다이렉트로 변경되어 짧은 유효기간의 일회성 로그인 세션을 생성합니다.
  * 공개 엔드포인트 GET /login/session/:sessionKey로 세션을 조회하면 세션 데이터(액세스/리프레시 토큰·만료 정보)를 반환 후 삭제합니다.

* **Bug Fixes**
  * 세션 없음·세션 만료에 대한 명확한 오류 메시지와 전용 오류 코드가 추가되었습니다.

* **Chores**
  * 런타임 유틸리티 관련 패키지(nanoid, uuid 등)가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->