### PR TITLE
feat: 레시피 요리 시작 API 반환값 변경 및 여러 번 요리/후기 작성 가능하도록 수정

### DIFF
--- a/src/api/review/review.service.spec.ts
+++ b/src/api/review/review.service.spec.ts
@@ -1,0 +1,315 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { ERROR_CODES } from '@/common/constants/error-codes';
+import { CustomException } from '@/common/exceptions/custom-exception';
+import { CommonCode } from '@/database/entity/common-code.entity';
+import { RecipeImage } from '@/database/entity/recipe-image.entity';
+import { Recipe } from '@/database/entity/recipe.entity';
+import { UserCompletedRecipe } from '@/database/entity/user-completed-recipe.entity';
+import { UserRecipeReview } from '@/database/entity/user-recipe-review.entity';
+import { User } from '@/database/entity/user.entity';
+import { CreateUserRecipeReviewDto } from './dto/create-user-recipe-review.dto';
+import { UserRecipeReviewService } from './review.service';
+
+describe('UserRecipeReviewService', () => {
+  let service: UserRecipeReviewService;
+
+  const mockUserRepository = {
+    findOne: jest.fn(),
+  };
+
+  const mockRecipeRepository = {
+    findOne: jest.fn(),
+  };
+
+  const mockUserCompletedRecipeRepository = {
+    findOne: jest.fn(),
+    update: jest.fn(),
+    count: jest.fn(),
+  };
+
+  const mockUserRecipeReviewRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    exists: jest.fn(),
+  };
+
+  const mockRecipeImageRepository = {
+    findOne: jest.fn(),
+  };
+
+  const mockCommonCodeRepository = {
+    find: jest.fn(),
+  };
+
+  const mockUser: User = {
+    id: 1,
+    email: 'test@example.com',
+    nickname: '테스트유저',
+    recipeCompleteCount: 0,
+    isFirstEntry: false,
+    level: 1,
+    profileImageUrl: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as User;
+
+  const mockCompletedRecipe: UserCompletedRecipe = {
+    id: 100,
+    userId: 1,
+    recipeId: 10,
+    isCompleted: true,
+    isReviewed: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as UserCompletedRecipe;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserRecipeReviewService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepository,
+        },
+        {
+          provide: getRepositoryToken(Recipe),
+          useValue: mockRecipeRepository,
+        },
+        {
+          provide: getRepositoryToken(UserCompletedRecipe),
+          useValue: mockUserCompletedRecipeRepository,
+        },
+        {
+          provide: getRepositoryToken(UserRecipeReview),
+          useValue: mockUserRecipeReviewRepository,
+        },
+        {
+          provide: getRepositoryToken(RecipeImage),
+          useValue: mockRecipeImageRepository,
+        },
+        {
+          provide: getRepositoryToken(CommonCode),
+          useValue: mockCommonCodeRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<UserRecipeReviewService>(UserRecipeReviewService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createReview', () => {
+    const userId = 1;
+    const completedRecipeId = 100;
+
+    it('후기를 성공적으로 작성해야 한다', async () => {
+      const createDto: CreateUserRecipeReviewDto = {
+        completedRecipeId,
+        tasteCode: 'R03001',
+        difficultyCode: 'R04001',
+        experienceCode: 'R05001',
+        content: '맛있게 잘 됐어요!',
+      };
+
+      const mockReview = {
+        id: 1,
+        userId,
+        userCompletedRecipeId: completedRecipeId,
+        tasteCode: createDto.tasteCode,
+        difficultyCode: createDto.difficultyCode,
+        experienceCode: createDto.experienceCode,
+        content: createDto.content,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as UserRecipeReview;
+
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockUserCompletedRecipeRepository.findOne.mockResolvedValue(
+        mockCompletedRecipe,
+      );
+      mockUserRecipeReviewRepository.create.mockReturnValue(mockReview);
+      mockUserRecipeReviewRepository.save.mockResolvedValue(mockReview);
+      mockUserCompletedRecipeRepository.update.mockResolvedValue(undefined);
+
+      const result = await service.createReview(userId, createDto);
+
+      expect(result).toEqual(mockReview);
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
+      expect(mockUserCompletedRecipeRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          id: completedRecipeId,
+          userId,
+        },
+      });
+      expect(mockUserRecipeReviewRepository.create).toHaveBeenCalledWith({
+        userId,
+        userCompletedRecipeId: completedRecipeId,
+        tasteCode: createDto.tasteCode,
+        difficultyCode: createDto.difficultyCode,
+        experienceCode: createDto.experienceCode,
+        content: createDto.content,
+      });
+      expect(mockUserRecipeReviewRepository.save).toHaveBeenCalled();
+      expect(mockUserCompletedRecipeRepository.update).toHaveBeenCalledWith(
+        completedRecipeId,
+        { isReviewed: true },
+      );
+    });
+
+    it('같은 completedRecipeId로 여러 번 후기를 작성할 수 있어야 한다', async () => {
+      const createDto1: CreateUserRecipeReviewDto = {
+        completedRecipeId,
+        tasteCode: 'R03001',
+        difficultyCode: 'R04001',
+        experienceCode: 'R05001',
+        content: '첫 번째 후기입니다!',
+      };
+
+      const createDto2: CreateUserRecipeReviewDto = {
+        completedRecipeId,
+        tasteCode: 'R03002',
+        difficultyCode: 'R04002',
+        experienceCode: 'R05002',
+        content: '두 번째 후기입니다!',
+      };
+
+      const createDto3: CreateUserRecipeReviewDto = {
+        completedRecipeId,
+        tasteCode: 'R03003',
+        difficultyCode: 'R04003',
+        experienceCode: 'R05003',
+        content: '세 번째 후기입니다!',
+      };
+
+      const mockReview1 = {
+        id: 1,
+        userId,
+        userCompletedRecipeId: completedRecipeId,
+        ...createDto1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as UserRecipeReview;
+
+      const mockReview2 = {
+        id: 2,
+        userId,
+        userCompletedRecipeId: completedRecipeId,
+        ...createDto2,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as UserRecipeReview;
+
+      const mockReview3 = {
+        id: 3,
+        userId,
+        userCompletedRecipeId: completedRecipeId,
+        ...createDto3,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as UserRecipeReview;
+
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockUserCompletedRecipeRepository.findOne.mockResolvedValue(
+        mockCompletedRecipe,
+      );
+      mockUserRecipeReviewRepository.create
+        .mockReturnValueOnce(mockReview1)
+        .mockReturnValueOnce(mockReview2)
+        .mockReturnValueOnce(mockReview3);
+      mockUserRecipeReviewRepository.save
+        .mockResolvedValueOnce(mockReview1)
+        .mockResolvedValueOnce(mockReview2)
+        .mockResolvedValueOnce(mockReview3);
+      mockUserCompletedRecipeRepository.update.mockResolvedValue(undefined);
+
+      // 첫 번째 후기 작성
+      const result1 = await service.createReview(userId, createDto1);
+      expect(result1.id).toBe(1);
+      expect(result1.content).toBe('첫 번째 후기입니다!');
+
+      // 두 번째 후기 작성
+      const result2 = await service.createReview(userId, createDto2);
+      expect(result2.id).toBe(2);
+      expect(result2.content).toBe('두 번째 후기입니다!');
+
+      // 세 번째 후기 작성
+      const result3 = await service.createReview(userId, createDto3);
+      expect(result3.id).toBe(3);
+      expect(result3.content).toBe('세 번째 후기입니다!');
+
+      // 각각 다른 리뷰 ID를 가져야 함
+      expect(result1.id).not.toBe(result2.id);
+      expect(result2.id).not.toBe(result3.id);
+      expect(result1.id).not.toBe(result3.id);
+
+      // create가 3번 호출되었는지 확인
+      expect(mockUserRecipeReviewRepository.create).toHaveBeenCalledTimes(3);
+      expect(mockUserRecipeReviewRepository.save).toHaveBeenCalledTimes(3);
+      expect(mockUserCompletedRecipeRepository.update).toHaveBeenCalledTimes(3);
+    });
+
+    it('존재하지 않는 사용자면 USER_NOT_FOUND 예외', async () => {
+      const createDto: CreateUserRecipeReviewDto = {
+        completedRecipeId,
+        content: '테스트 후기',
+      };
+
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.createReview(userId, createDto)).rejects.toThrow(
+        CustomException,
+      );
+      await expect(service.createReview(userId, createDto)).rejects.toThrow(
+        ERROR_CODES.USER_NOT_FOUND.message,
+      );
+    });
+
+    it('존재하지 않거나 완료되지 않은 completedRecipeId면 REVIEW_NOT_ALLOWED 예외', async () => {
+      const createDto: CreateUserRecipeReviewDto = {
+        completedRecipeId,
+        content: '테스트 후기',
+      };
+
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockUserCompletedRecipeRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.createReview(userId, createDto)).rejects.toThrow(
+        CustomException,
+      );
+      await expect(service.createReview(userId, createDto)).rejects.toThrow(
+        ERROR_CODES.REVIEW_NOT_ALLOWED.message,
+      );
+    });
+
+    it('완료되지 않은 레시피에 대한 후기는 REVIEW_NOT_ALLOWED 예외', async () => {
+      const createDto: CreateUserRecipeReviewDto = {
+        completedRecipeId,
+        content: '테스트 후기',
+      };
+
+      const incompleteRecipe = {
+        ...mockCompletedRecipe,
+        isCompleted: false,
+      };
+
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockUserCompletedRecipeRepository.findOne.mockResolvedValue(
+        incompleteRecipe,
+      );
+
+      await expect(service.createReview(userId, createDto)).rejects.toThrow(
+        CustomException,
+      );
+      await expect(service.createReview(userId, createDto)).rejects.toThrow(
+        ERROR_CODES.REVIEW_NOT_ALLOWED.message,
+      );
+    });
+  });
+});

--- a/src/api/review/review.service.ts
+++ b/src/api/review/review.service.ts
@@ -2,14 +2,14 @@ import { HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 
-import { UserRecipeReview } from '@/database/entity/user-recipe-review.entity';
-import { User } from '@/database/entity/user.entity';
+import { ERROR_CODES } from '@/common/constants/error-codes';
+import { CustomException } from '@/common/exceptions/custom-exception';
+import { CommonCode } from '@/database/entity/common-code.entity';
+import { RecipeImage } from '@/database/entity/recipe-image.entity';
 import { Recipe } from '@/database/entity/recipe.entity';
 import { UserCompletedRecipe } from '@/database/entity/user-completed-recipe.entity';
-import { RecipeImage } from '@/database/entity/recipe-image.entity';
-import { CommonCode } from '@/database/entity/common-code.entity';
-import { CustomException } from '@/common/exceptions/custom-exception';
-import { ERROR_CODES } from '@/common/constants/error-codes';
+import { UserRecipeReview } from '@/database/entity/user-recipe-review.entity';
+import { User } from '@/database/entity/user.entity';
 import { CreateUserRecipeReviewDto } from './dto/create-user-recipe-review.dto';
 import {
   GetUserRecipeReviewPreparationQueryDto,
@@ -63,24 +63,25 @@ export class UserRecipeReviewService {
       );
     }
 
-    if (completedRecipe.isReviewed) {
-      throw new CustomException(
-        ERROR_CODES.REVIEW_ALREADY_EXISTS,
-        HttpStatus.CONFLICT,
-      );
-    }
+    // 후기 중복 체크 제거, 한 사용자가 여러 번 후기를 등록할 수 있도록 수정
+    // if (completedRecipe.isReviewed) {
+    //   throw new CustomException(
+    //     ERROR_CODES.REVIEW_ALREADY_EXISTS,
+    //     HttpStatus.CONFLICT,
+    //   );
+    // }
 
-    const alreadyReviewed = await this.userRecipeReviewRepository.exists({
-      where: {
-        userCompletedRecipeId: completedRecipe.id,
-      },
-    });
-    if (alreadyReviewed) {
-      throw new CustomException(
-        ERROR_CODES.REVIEW_ALREADY_EXISTS,
-        HttpStatus.CONFLICT,
-      );
-    }
+    // const alreadyReviewed = await this.userRecipeReviewRepository.exists({
+    //   where: {
+    //     userCompletedRecipeId: completedRecipe.id,
+    //   },
+    // });
+    // if (alreadyReviewed) {
+    //   throw new CustomException(
+    //     ERROR_CODES.REVIEW_ALREADY_EXISTS,
+    //     HttpStatus.CONFLICT,
+    //   );
+    // }
 
     const review = this.userRecipeReviewRepository.create({
       userId,

--- a/src/api/review/review.service.ts
+++ b/src/api/review/review.service.ts
@@ -63,25 +63,24 @@ export class UserRecipeReviewService {
       );
     }
 
-    // 후기 중복 체크 제거, 한 사용자가 여러 번 후기를 등록할 수 있도록 수정
-    // if (completedRecipe.isReviewed) {
-    //   throw new CustomException(
-    //     ERROR_CODES.REVIEW_ALREADY_EXISTS,
-    //     HttpStatus.CONFLICT,
-    //   );
-    // }
+    if (completedRecipe.isReviewed) {
+      throw new CustomException(
+        ERROR_CODES.REVIEW_ALREADY_EXISTS,
+        HttpStatus.CONFLICT,
+      );
+    }
 
-    // const alreadyReviewed = await this.userRecipeReviewRepository.exists({
-    //   where: {
-    //     userCompletedRecipeId: completedRecipe.id,
-    //   },
-    // });
-    // if (alreadyReviewed) {
-    //   throw new CustomException(
-    //     ERROR_CODES.REVIEW_ALREADY_EXISTS,
-    //     HttpStatus.CONFLICT,
-    //   );
-    // }
+    const alreadyReviewed = await this.userRecipeReviewRepository.exists({
+      where: {
+        userCompletedRecipeId: completedRecipe.id,
+      },
+    });
+    if (alreadyReviewed) {
+      throw new CustomException(
+        ERROR_CODES.REVIEW_ALREADY_EXISTS,
+        HttpStatus.CONFLICT,
+      );
+    }
 
     const review = this.userRecipeReviewRepository.create({
       userId,

--- a/src/api/user-recipe-archive/user-recipe-archive.controller.ts
+++ b/src/api/user-recipe-archive/user-recipe-archive.controller.ts
@@ -116,9 +116,12 @@ export class UserRecipeArchiveController {
     properties: {
       completedRecipeId: {
         type: 'number',
-        example: 123,
+        example: 8,
         description: '생성된 UserCompletedRecipe의 id',
       },
+    },
+    example: {
+      completedRecipeId: 8,
     },
   })
   @ApiErrorResponse(HttpStatus.UNAUTHORIZED, ERROR_CODES.AUTH_REQUIRED)

--- a/src/api/user-recipe-archive/user-recipe-archive.controller.ts
+++ b/src/api/user-recipe-archive/user-recipe-archive.controller.ts
@@ -112,8 +112,14 @@ export class UserRecipeArchiveController {
   @Post(':recipeId/start')
   @ApiOperation({ summary: '레시피 요리 시작 (바로 해먹기)' })
   @ApiSuccessResponse('레시피 요리 시작 성공', {
-    type: 'boolean',
-    example: true,
+    type: 'object',
+    properties: {
+      completedRecipeId: {
+        type: 'number',
+        example: 123,
+        description: '생성된 UserCompletedRecipe의 id',
+      },
+    },
   })
   @ApiErrorResponse(HttpStatus.UNAUTHORIZED, ERROR_CODES.AUTH_REQUIRED)
   @ApiErrorResponse(HttpStatus.NOT_FOUND, ERROR_CODES.USER_NOT_FOUND)
@@ -121,12 +127,12 @@ export class UserRecipeArchiveController {
   async startRecipeCooking(
     @Request() req: any,
     @Param('recipeId', ParseIntPipe) recipeId: number,
-  ): Promise<boolean> {
+  ): Promise<{ completedRecipeId: number }> {
     const userId = req.user.sub;
     return this.archiveService.startRecipeCooking(userId, recipeId);
   }
 
-  @Post(':recipeId/complete')
+  @Post(':completedRecipeId/complete')
   @ApiOperation({ summary: '레시피 완료' })
   @ApiSuccessResponse('레시피 완료 성공', { type: 'boolean', example: true })
   @ApiErrorResponse(HttpStatus.UNAUTHORIZED, ERROR_CODES.AUTH_REQUIRED)
@@ -134,10 +140,10 @@ export class UserRecipeArchiveController {
   @ApiErrorResponse(HttpStatus.NOT_FOUND, ERROR_CODES.RECIPE_NOT_FOUND)
   async completeRecipe(
     @Request() req: any,
-    @Param('recipeId', ParseIntPipe) recipeId: number,
+    @Param('completedRecipeId', ParseIntPipe) completedRecipeId: number,
   ): Promise<boolean> {
     const userId = req.user.sub;
-    return await this.archiveService.completeRecipe(userId, recipeId);
+    return await this.archiveService.completeRecipe(userId, completedRecipeId);
   }
 
   @Get('completed')

--- a/src/api/user-recipe-archive/user-recipe-archive.service.spec.ts
+++ b/src/api/user-recipe-archive/user-recipe-archive.service.spec.ts
@@ -322,15 +322,16 @@ describe('UserRecipeArchiveService', () => {
     const userId = 1;
     const recipeId = 1;
 
-    it('UserService의 startRecipeCooking 메서드를 호출해야 함', async () => {
+    it('UserService의 startRecipeCooking 메서드를 호출하고 completedRecipeId를 반환해야 함', async () => {
       // Given
-      mockUserService.startRecipeCooking.mockResolvedValue(true);
+      const mockResult = { completedRecipeId: 123 };
+      mockUserService.startRecipeCooking.mockResolvedValue(mockResult);
 
       // When
       const result = await service.startRecipeCooking(userId, recipeId);
 
       // Then
-      expect(result).toBe(true);
+      expect(result).toEqual({ completedRecipeId: 123 });
       expect(mockUserService.startRecipeCooking).toHaveBeenCalledWith(
         userId,
         recipeId,

--- a/src/api/user-recipe-archive/user-recipe-archive.service.ts
+++ b/src/api/user-recipe-archive/user-recipe-archive.service.ts
@@ -140,12 +140,18 @@ export class UserRecipeArchiveService {
     );
   }
 
-  async startRecipeCooking(userId: number, recipeId: number): Promise<boolean> {
+  async startRecipeCooking(
+    userId: number,
+    recipeId: number,
+  ): Promise<{ completedRecipeId: number }> {
     return this.userService.startRecipeCooking(userId, recipeId);
   }
 
-  async completeRecipe(userId: number, recipeId: number): Promise<boolean> {
-    return this.userService.completeRecipe(userId, recipeId);
+  async completeRecipe(
+    userId: number,
+    completedRecipeId: number,
+  ): Promise<boolean> {
+    return this.userService.completeRecipe(userId, completedRecipeId);
   }
 
   async getCompletedRecipes(

--- a/src/api/user/user.service.spec.ts
+++ b/src/api/user/user.service.spec.ts
@@ -3,12 +3,13 @@ import { ERROR_CODES } from '@/common/constants/error-codes';
 import { CustomException } from '@/common/exceptions/custom-exception';
 import { LoggerFactoryService } from '@/common/logger/logger-factory.service';
 import { CommonCode } from '@/database/entity/common-code.entity';
+import { Ingredient } from '@/database/entity/ingredient.entity';
 import { Recipe } from '@/database/entity/recipe.entity';
 import { UserCompletedRecipe } from '@/database/entity/user-completed-recipe.entity';
+import { UserDailyConditions } from '@/database/entity/user-daily-conditions.entity';
 import { UserRecentRecipes } from '@/database/entity/user-recent-recipes.entity';
 import { UserRecipeBookmark } from '@/database/entity/user-recipe-bookmark.entity';
 import { User } from '@/database/entity/user.entity';
-import { UserDailyConditions } from '@/database/entity/user-daily-conditions.entity';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { SocialLoginService } from '../social-login/social-login.service';
@@ -16,7 +17,6 @@ import { UserRole } from './enums/role.enum';
 import { UserRecentRecipesCustomRepository } from './user-recent-recipes.custom-repository';
 import { UserRecipeBookmarkCustomRepository } from './user-recipe-bookmark.custom-repository';
 import { UserService } from './user.service';
-import { Ingredient } from '@/database/entity/ingredient.entity';
 
 describe('UserService', () => {
   let service: UserService;
@@ -172,106 +172,111 @@ describe('UserService', () => {
 
   describe('completeRecipe', () => {
     const userId = 1;
-    const recipeId = 10;
+    const completedRecipeId = 100;
 
     it('레시피를 성공적으로 완료해야 한다', async () => {
-      const existingCookingRecord = {
+      const existingCookingRecord: UserCompletedRecipe = {
+        id: completedRecipeId,
         userId,
-        recipeId,
+        recipeId: 10,
         isCompleted: false,
         isReviewed: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as UserCompletedRecipe;
+
+      const updatedUser = {
+        ...mockUser,
+        recipeCompleteCount: 1,
+        level: 1,
       };
 
       mockUserRepository.findOne.mockResolvedValue(mockUser);
-      mockRecipeRepository.findOne.mockResolvedValue(mockRecipe);
       mockUserCompletedRecipeRepository.findOne.mockResolvedValue(
         existingCookingRecord,
       );
-      mockUserCompletedRecipeRepository.save.mockResolvedValue({});
-      mockUserRepository.save.mockResolvedValue(mockUser);
+      mockUserCompletedRecipeRepository.save.mockResolvedValue({
+        ...existingCookingRecord,
+        isCompleted: true,
+      });
+      mockUserRepository.save.mockResolvedValue(updatedUser);
 
-      const result = await service.completeRecipe(userId, recipeId);
+      // logCompletionHistory를 위한 mock
+      jest
+        .spyOn(service as any, 'logCompletionHistory')
+        .mockResolvedValue(undefined);
+
+      const result = await service.completeRecipe(userId, completedRecipeId);
 
       expect(result).toBe(true);
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
       });
-      expect(mockRecipeRepository.findOne).toHaveBeenCalledWith({
-        where: { id: recipeId },
-      });
       expect(mockUserCompletedRecipeRepository.findOne).toHaveBeenCalledWith({
-        where: { userId, recipeId },
+        where: { id: completedRecipeId },
       });
-      expect(mockUserCompletedRecipeRepository.save).toHaveBeenCalledWith({
-        userId,
-        recipeId,
-        isCompleted: true,
-        isReviewed: false,
-      });
-      expect(mockUserRepository.save).toHaveBeenCalledWith({
-        ...mockUser,
-        recipeCompleteCount: 1,
-      });
+      expect(mockUserCompletedRecipeRepository.save).toHaveBeenCalled();
+      expect(mockUserRepository.save).toHaveBeenCalled();
     });
 
-    it('이미 완료된 레시피를 다시 완료할 경우 true를 반환해야 한다', async () => {
+    it('이미 완료된 레시피를 다시 완료할 경우에도 완료 처리를 수행해야 한다', async () => {
       const existingCompletion: UserCompletedRecipe = {
-        id: 1,
+        id: completedRecipeId,
         userId,
-        recipeId,
+        recipeId: 10,
         isCompleted: true,
         isReviewed: false,
         createdAt: new Date(),
         updatedAt: new Date(),
       } as UserCompletedRecipe;
 
+      const updatedUser = {
+        ...mockUser,
+        recipeCompleteCount: 1,
+        level: 1,
+      };
+
       mockUserRepository.findOne.mockResolvedValue(mockUser);
-      mockRecipeRepository.findOne.mockResolvedValue(mockRecipe);
       mockUserCompletedRecipeRepository.findOne.mockResolvedValue(
         existingCompletion,
       );
+      mockUserCompletedRecipeRepository.save.mockResolvedValue(
+        existingCompletion,
+      );
+      mockUserRepository.save.mockResolvedValue(updatedUser);
 
-      const result = await service.completeRecipe(userId, recipeId);
+      jest
+        .spyOn(service as any, 'logCompletionHistory')
+        .mockResolvedValue(undefined);
+
+      const result = await service.completeRecipe(userId, completedRecipeId);
 
       expect(result).toBe(true);
-      expect(mockUserCompletedRecipeRepository.save).not.toHaveBeenCalled();
-      expect(mockUserRepository.save).not.toHaveBeenCalled();
+      expect(mockUserCompletedRecipeRepository.save).toHaveBeenCalled();
+      expect(mockUserRepository.save).toHaveBeenCalled();
     });
 
     it('존재하지 않는 사용자로 완료할 경우 USER_NOT_FOUND 예외', async () => {
       mockUserRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.completeRecipe(userId, recipeId)).rejects.toThrow(
-        CustomException,
-      );
-      await expect(service.completeRecipe(userId, recipeId)).rejects.toThrow(
-        ERROR_CODES.USER_NOT_FOUND.message,
-      );
-    });
-
-    it('존재하지 않는 레시피로 완료할 경우 RECIPE_NOT_FOUND 예외', async () => {
-      mockUserRepository.findOne.mockResolvedValue(mockUser);
-      mockRecipeRepository.findOne.mockResolvedValue(null);
-
-      await expect(service.completeRecipe(userId, recipeId)).rejects.toThrow(
-        CustomException,
-      );
-      await expect(service.completeRecipe(userId, recipeId)).rejects.toThrow(
-        ERROR_CODES.RECIPE_NOT_FOUND.message,
-      );
+      await expect(
+        service.completeRecipe(userId, completedRecipeId),
+      ).rejects.toThrow(CustomException);
+      await expect(
+        service.completeRecipe(userId, completedRecipeId),
+      ).rejects.toThrow(ERROR_CODES.USER_NOT_FOUND.message);
     });
 
     it('요리 시작 기록이 없으면 RECIPE_COOKING_NOT_STARTED 예외', async () => {
       mockUserRepository.findOne.mockResolvedValue(mockUser);
-      mockRecipeRepository.findOne.mockResolvedValue(mockRecipe);
       mockUserCompletedRecipeRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.completeRecipe(userId, recipeId)).rejects.toThrow(
-        CustomException,
-      );
-      await expect(service.completeRecipe(userId, recipeId)).rejects.toThrow(
-        ERROR_CODES.RECIPE_COOKING_NOT_STARTED.message,
-      );
+      await expect(
+        service.completeRecipe(userId, completedRecipeId),
+      ).rejects.toThrow(CustomException);
+      await expect(
+        service.completeRecipe(userId, completedRecipeId),
+      ).rejects.toThrow(ERROR_CODES.RECIPE_COOKING_NOT_STARTED.message);
     });
   });
 
@@ -281,6 +286,7 @@ describe('UserService', () => {
 
     it('레시피 요리를 성공적으로 시작해야 한다', async () => {
       const mockCreatedEntity = {
+        id: 123,
         userId,
         recipeId,
         isCompleted: false,
@@ -289,7 +295,6 @@ describe('UserService', () => {
 
       mockUserRepository.findOne.mockResolvedValue(mockUser);
       mockRecipeRepository.findOne.mockResolvedValue(mockRecipe);
-      mockUserCompletedRecipeRepository.findOne.mockResolvedValue(null);
       mockUserCompletedRecipeRepository.create.mockReturnValue(
         mockCreatedEntity,
       );
@@ -299,15 +304,12 @@ describe('UserService', () => {
 
       const result = await service.startRecipeCooking(userId, recipeId);
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ completedRecipeId: 123 });
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
       });
       expect(mockRecipeRepository.findOne).toHaveBeenCalledWith({
         where: { id: recipeId },
-      });
-      expect(mockUserCompletedRecipeRepository.findOne).toHaveBeenCalledWith({
-        where: { userId, recipeId },
       });
       expect(mockUserCompletedRecipeRepository.create).toHaveBeenCalledWith({
         userId,
@@ -320,28 +322,29 @@ describe('UserService', () => {
       );
     });
 
-    it('이미 시작된 경우 true 반환', async () => {
-      const existingCookingRecord: UserCompletedRecipe = {
-        id: 1,
+    it('새로운 요리 시작 기록을 생성하고 completedRecipeId를 반환해야 한다', async () => {
+      const mockCreatedEntity = {
+        id: 456,
         userId,
         recipeId,
         isCompleted: false,
         isReviewed: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      } as UserCompletedRecipe;
+      };
 
       mockUserRepository.findOne.mockResolvedValue(mockUser);
       mockRecipeRepository.findOne.mockResolvedValue(mockRecipe);
-      mockUserCompletedRecipeRepository.findOne.mockResolvedValue(
-        existingCookingRecord,
+      mockUserCompletedRecipeRepository.create.mockReturnValue(
+        mockCreatedEntity,
+      );
+      mockUserCompletedRecipeRepository.save.mockResolvedValue(
+        mockCreatedEntity,
       );
 
       const result = await service.startRecipeCooking(userId, recipeId);
 
-      expect(result).toBe(true);
-      expect(mockUserCompletedRecipeRepository.create).not.toHaveBeenCalled();
-      expect(mockUserCompletedRecipeRepository.save).not.toHaveBeenCalled();
+      expect(result).toEqual({ completedRecipeId: 456 });
+      expect(mockUserCompletedRecipeRepository.create).toHaveBeenCalled();
+      expect(mockUserCompletedRecipeRepository.save).toHaveBeenCalled();
     });
 
     it('존재하지 않는 사용자면 USER_NOT_FOUND', async () => {
@@ -365,6 +368,79 @@ describe('UserService', () => {
       await expect(
         service.startRecipeCooking(userId, recipeId),
       ).rejects.toThrow(ERROR_CODES.RECIPE_NOT_FOUND.message);
+    });
+
+    it('같은 레시피를 여러 번 요리 시작할 수 있어야 한다', async () => {
+      // 첫 번째 요리 시작
+      const firstEntity = {
+        id: 101,
+        userId,
+        recipeId,
+        isCompleted: false,
+        isReviewed: false,
+      };
+
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockRecipeRepository.findOne.mockResolvedValue(mockRecipe);
+      mockUserCompletedRecipeRepository.create
+        .mockReturnValueOnce(firstEntity)
+        .mockReturnValueOnce({
+          id: 102,
+          userId,
+          recipeId,
+          isCompleted: false,
+          isReviewed: false,
+        })
+        .mockReturnValueOnce({
+          id: 103,
+          userId,
+          recipeId,
+          isCompleted: false,
+          isReviewed: false,
+        });
+      mockUserCompletedRecipeRepository.save
+        .mockResolvedValueOnce(firstEntity)
+        .mockResolvedValueOnce({
+          id: 102,
+          userId,
+          recipeId,
+          isCompleted: false,
+          isReviewed: false,
+        })
+        .mockResolvedValueOnce({
+          id: 103,
+          userId,
+          recipeId,
+          isCompleted: false,
+          isReviewed: false,
+        });
+
+      // 첫 번째 요리 시작
+      const firstResult = await service.startRecipeCooking(userId, recipeId);
+      expect(firstResult).toEqual({ completedRecipeId: 101 });
+
+      // 두 번째 요리 시작
+      const secondResult = await service.startRecipeCooking(userId, recipeId);
+      expect(secondResult).toEqual({ completedRecipeId: 102 });
+
+      // 세 번째 요리 시작
+      const thirdResult = await service.startRecipeCooking(userId, recipeId);
+      expect(thirdResult).toEqual({ completedRecipeId: 103 });
+
+      // 각각 다른 completedRecipeId를 반환해야 함
+      expect(firstResult.completedRecipeId).not.toBe(
+        secondResult.completedRecipeId,
+      );
+      expect(secondResult.completedRecipeId).not.toBe(
+        thirdResult.completedRecipeId,
+      );
+      expect(firstResult.completedRecipeId).not.toBe(
+        thirdResult.completedRecipeId,
+      );
+
+      // create가 3번 호출되었는지 확인
+      expect(mockUserCompletedRecipeRepository.create).toHaveBeenCalledTimes(3);
+      expect(mockUserCompletedRecipeRepository.save).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/src/api/user/user.service.ts
+++ b/src/api/user/user.service.ts
@@ -15,6 +15,7 @@ import {
 } from '@/database/entity/user-daily-conditions.entity';
 import { UserRecentRecipes } from '@/database/entity/user-recent-recipes.entity';
 import { UserRecipeBookmark } from '@/database/entity/user-recipe-bookmark.entity';
+import { UserUnavailableIngredient } from '@/database/entity/user-unavailable-ingredient.entity';
 import { User } from '@/database/entity/user.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -42,7 +43,6 @@ import { UserDto } from './dto/user.dto';
 import { UserRole } from './enums/role.enum';
 import { UserRecentRecipesCustomRepository } from './user-recent-recipes.custom-repository';
 import { UserRecipeBookmarkCustomRepository } from './user-recipe-bookmark.custom-repository';
-import { UserUnavailableIngredient } from '@/database/entity/user-unavailable-ingredient.entity';
 
 @Injectable()
 export class UserService {
@@ -332,7 +332,10 @@ export class UserService {
   /**
    * 사용자가 레시피를 완료합니다.
    */
-  async completeRecipe(userId: number, recipeId: number): Promise<boolean> {
+  async completeRecipe(
+    userId: number,
+    completedRecipeId: number,
+  ): Promise<boolean> {
     // 사용자 존재 여부 확인
     const user = await this.userRepository.findOne({
       where: { id: userId },
@@ -342,33 +345,19 @@ export class UserService {
       throw new CustomException(ERROR_CODES.USER_NOT_FOUND);
     }
 
-    // 레시피 존재 여부 확인
-    const recipe = await this.recipeRepository.findOne({
-      where: { id: recipeId },
-    });
-
-    if (!recipe) {
-      throw new CustomException(ERROR_CODES.RECIPE_NOT_FOUND);
-    }
-
     // 기존 요리 시작 기록 확인
     const existing = await this.userCompletedRecipeRepository.findOne({
-      where: { userId, recipeId },
+      where: { id: completedRecipeId },
     });
 
-    if (existing) {
-      // 이미 완료된 레시피인지 확인
-      if (existing.isCompleted) {
-        return true; // 이미 완료된 경우 true 반환
-      }
-
-      // 요리 시작 기록을 완료로 업데이트
-      existing.isCompleted = true;
-      await this.userCompletedRecipeRepository.save(existing);
-    } else {
+    if (!existing) {
       // 요리 시작 기록이 없는 경우 오류 반환
       throw new CustomException(ERROR_CODES.RECIPE_COOKING_NOT_STARTED);
     }
+
+    // 요리 시작 기록을 완료로 업데이트
+    existing.isCompleted = true;
+    await this.userCompletedRecipeRepository.save(existing);
 
     // 사용자 완료 횟수 증가
     user.recipeCompleteCount = (user.recipeCompleteCount || 0) + 1;
@@ -386,7 +375,7 @@ export class UserService {
     await this.userRepository.save(user);
 
     // 완료 이력 기록
-    await this.logCompletionHistory(userId, recipeId);
+    await this.logCompletionHistory(userId, existing.recipeId);
 
     return true;
   }
@@ -394,7 +383,10 @@ export class UserService {
   /**
    * 사용자가 레시피 요리를 시작합니다.
    */
-  async startRecipeCooking(userId: number, recipeId: number): Promise<boolean> {
+  async startRecipeCooking(
+    userId: number,
+    recipeId: number,
+  ): Promise<{ completedRecipeId: number }> {
     // 사용자 존재 여부 확인
     const user = await this.userRepository.findOne({
       where: { id: userId },
@@ -413,15 +405,15 @@ export class UserService {
       throw new CustomException(ERROR_CODES.RECIPE_NOT_FOUND);
     }
 
-    // 이미 요리를 시작했는지 확인
-    const existing = await this.userCompletedRecipeRepository.findOne({
-      where: { userId, recipeId },
-    });
+    // 한 사용자가 요리 여러 번 시작 가능
+    // const existing = await this.userCompletedRecipeRepository.findOne({
+    //   where: { userId, recipeId },
+    // });
 
-    if (existing) {
-      // 이미 요리를 시작했다면 기존 레코드 반환
-      return true;
-    }
+    // if (existing) {
+    //   // 이미 요리를 시작했다면 기존 레코드 반환
+    //   return true;
+    // }
 
     // 요리 시작 기록 생성 (isCompleted: false)
     const entity = this.userCompletedRecipeRepository.create({
@@ -432,7 +424,7 @@ export class UserService {
     });
     await this.userCompletedRecipeRepository.save(entity);
 
-    return true;
+    return { completedRecipeId: entity.id };
   }
 
   private async getUnavailableIngredients(

--- a/test/e2e/recipe-recommendation.e2e-spec.ts
+++ b/test/e2e/recipe-recommendation.e2e-spec.ts
@@ -6,6 +6,8 @@ import {
   TEST_TAGS,
 } from '../helpers/auth.helper';
 import { MockAppModule } from '../mocks/app.mock';
+import { resetReviewMocks } from '../mocks/review.mock';
+import { resetUserMocks } from '../mocks/user.mock';
 
 describe('RecipeRecommendation (E2E)', () => {
   let app: INestApplication;
@@ -32,6 +34,9 @@ describe('RecipeRecommendation (E2E)', () => {
   });
 
   afterAll(async () => {
+    // 테스트 격리를 위해 Mock 상태 초기화
+    resetUserMocks();
+    resetReviewMocks();
     await app.close();
   });
 

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -6,6 +6,8 @@ import {
   TEST_TAGS,
 } from '../helpers/auth.helper';
 import { MockAppModule } from '../mocks/app.mock';
+import { resetReviewMocks } from '../mocks/review.mock';
+import { resetUserMocks } from '../mocks/user.mock';
 
 describe('UserController (E2E)', () => {
   let app: INestApplication;
@@ -30,6 +32,9 @@ describe('UserController (E2E)', () => {
   });
 
   afterAll(async () => {
+    // 테스트 격리를 위해 Mock 상태 초기화
+    resetUserMocks();
+    resetReviewMocks();
     await app.close();
   });
 

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -57,7 +57,8 @@ describe('UserController (E2E)', () => {
         `/v1/users/recipes/${testRecipeId}/start`,
       ).expect(HttpStatus.CREATED);
 
-      expect(response.body.data).toBe(true);
+      expect(response.body.data).toHaveProperty('completedRecipeId');
+      expect(typeof response.body.data.completedRecipeId).toBe('number');
     });
 
     it(`${TEST_TAGS.AUTHENTICATED} 3단계: 레시피 요리 완료 - /users/recipes/:recipeId/complete (POST)`, async () => {
@@ -221,6 +222,163 @@ describe('UserController (E2E)', () => {
       expect(response.body.data.limit).toBe(2);
       expect(Array.isArray(response.body.data.items)).toBe(true);
       expect(response.body.data.items.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('같은 레시피를 여러 번 요리 시작 -> 완료 -> 후기 작성 플로우', () => {
+    const testRecipeId = 3; // 테스트용 레시피 ID
+    const completedRecipeIds: number[] = [];
+
+    it(`${TEST_TAGS.AUTHENTICATED} 1차: 레시피 요리 시작`, async () => {
+      const response = await authenticatedRequest(
+        app,
+        'post',
+        `/v1/users/recipes/${testRecipeId}/start`,
+      ).expect(HttpStatus.CREATED);
+
+      expect(response.body.data).toHaveProperty('completedRecipeId');
+      expect(typeof response.body.data.completedRecipeId).toBe('number');
+      completedRecipeIds.push(response.body.data.completedRecipeId);
+    });
+
+    it(`${TEST_TAGS.AUTHENTICATED} 1차: 레시피 요리 완료`, async () => {
+      const completedRecipeId = completedRecipeIds[0];
+      const response = await authenticatedRequest(
+        app,
+        'post',
+        `/v1/users/recipes/${completedRecipeId}/complete`,
+      ).expect(HttpStatus.CREATED);
+
+      expect(response.body.data).toBe(true);
+    });
+
+    it(`${TEST_TAGS.AUTHENTICATED} 1차: 레시피 후기 작성`, async () => {
+      const completedRecipeId = completedRecipeIds[0];
+      const createReviewDto = {
+        completedRecipeId,
+        tasteCode: 'R03001',
+        difficultyCode: 'R04001',
+        experienceCode: 'R05001',
+        content: '첫 번째 시도였는데 정말 맛있게 잘 됐어요!',
+      };
+
+      const response = await authenticatedRequest(app, 'post', '/v1/reviews')
+        .send(createReviewDto)
+        .expect(HttpStatus.CREATED);
+
+      expect(response.body.data).toHaveProperty('id');
+      expect(response.body.data).toHaveProperty('userId');
+      expect(response.body.data).toHaveProperty('userCompletedRecipeId');
+      expect(response.body.data.userCompletedRecipeId).toBe(completedRecipeId);
+      expect(response.body.data.tasteCode).toBe(createReviewDto.tasteCode);
+      expect(response.body.data.content).toBe(createReviewDto.content);
+    });
+
+    it(`${TEST_TAGS.AUTHENTICATED} 2차: 같은 레시피 요리 시작 (새로운 completedRecipeId 반환)`, async () => {
+      const response = await authenticatedRequest(
+        app,
+        'post',
+        `/v1/users/recipes/${testRecipeId}/start`,
+      ).expect(HttpStatus.CREATED);
+
+      expect(response.body.data).toHaveProperty('completedRecipeId');
+      expect(typeof response.body.data.completedRecipeId).toBe('number');
+
+      // 이전 completedRecipeId와 다른지 확인
+      expect(response.body.data.completedRecipeId).not.toBe(
+        completedRecipeIds[0],
+      );
+
+      completedRecipeIds.push(response.body.data.completedRecipeId);
+    });
+
+    it(`${TEST_TAGS.AUTHENTICATED} 2차: 레시피 요리 완료`, async () => {
+      const completedRecipeId = completedRecipeIds[1];
+      const response = await authenticatedRequest(
+        app,
+        'post',
+        `/v1/users/recipes/${completedRecipeId}/complete`,
+      ).expect(HttpStatus.CREATED);
+
+      expect(response.body.data).toBe(true);
+    });
+
+    it(`${TEST_TAGS.AUTHENTICATED} 2차: 레시피 후기 작성`, async () => {
+      const completedRecipeId = completedRecipeIds[1];
+      const createReviewDto = {
+        completedRecipeId,
+        tasteCode: 'R03002',
+        difficultyCode: 'R04002',
+        experienceCode: 'R05002',
+        content: '두 번째 시도에서는 더 나은 결과를 얻었어요!',
+      };
+
+      const response = await authenticatedRequest(app, 'post', '/v1/reviews')
+        .send(createReviewDto)
+        .expect(HttpStatus.CREATED);
+
+      expect(response.body.data).toHaveProperty('id');
+      expect(response.body.data.userCompletedRecipeId).toBe(completedRecipeId);
+      expect(response.body.data.tasteCode).toBe(createReviewDto.tasteCode);
+      expect(response.body.data.content).toBe(createReviewDto.content);
+
+      // 첫 번째 후기와 다른 ID인지 확인
+      expect(response.body.data.id).toBeDefined();
+    });
+
+    it(`${TEST_TAGS.AUTHENTICATED} 3차: 같은 레시피 요리 시작 (세 번째 completedRecipeId 반환)`, async () => {
+      const response = await authenticatedRequest(
+        app,
+        'post',
+        `/v1/users/recipes/${testRecipeId}/start`,
+      ).expect(HttpStatus.CREATED);
+
+      expect(response.body.data).toHaveProperty('completedRecipeId');
+      expect(typeof response.body.data.completedRecipeId).toBe('number');
+
+      // 이전 completedRecipeId들과 다른지 확인
+      expect(completedRecipeIds).not.toContain(
+        response.body.data.completedRecipeId,
+      );
+
+      completedRecipeIds.push(response.body.data.completedRecipeId);
+    });
+
+    it(`${TEST_TAGS.AUTHENTICATED} 3차: 레시피 요리 완료`, async () => {
+      const completedRecipeId = completedRecipeIds[2];
+      const response = await authenticatedRequest(
+        app,
+        'post',
+        `/v1/users/recipes/${completedRecipeId}/complete`,
+      ).expect(HttpStatus.CREATED);
+
+      expect(response.body.data).toBe(true);
+    });
+
+    it(`${TEST_TAGS.AUTHENTICATED} 3차: 레시피 후기 작성`, async () => {
+      const completedRecipeId = completedRecipeIds[2];
+      const createReviewDto = {
+        completedRecipeId,
+        tasteCode: 'R03003',
+        difficultyCode: 'R04003',
+        experienceCode: 'R05003',
+        content: '세 번째 시도에서 완벽하게 만들었어요! 이제 마스터입니다.',
+      };
+
+      const response = await authenticatedRequest(app, 'post', '/v1/reviews')
+        .send(createReviewDto)
+        .expect(HttpStatus.CREATED);
+
+      expect(response.body.data).toHaveProperty('id');
+      expect(response.body.data.userCompletedRecipeId).toBe(completedRecipeId);
+      expect(response.body.data.tasteCode).toBe(createReviewDto.tasteCode);
+      expect(response.body.data.content).toBe(createReviewDto.content);
+    });
+
+    it(`${TEST_TAGS.AUTHENTICATED} 검증: 모든 completedRecipeId가 서로 다른지 확인`, () => {
+      // 3개의 completedRecipeId가 모두 다른지 확인
+      expect(completedRecipeIds.length).toBe(3);
+      expect(new Set(completedRecipeIds).size).toBe(3); // 중복이 없어야 함
     });
   });
 });

--- a/test/mocks/app.mock.ts
+++ b/test/mocks/app.mock.ts
@@ -5,6 +5,7 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
 import { MockAuthModule } from './auth.mock';
 import { MockDatabaseModule } from './database.mock';
 import { MockRecipeModule } from './recipe.mock';
+import { MockReviewModule } from './review.mock';
 import { MockUserModule } from './user.mock';
 
 @Module({
@@ -16,6 +17,7 @@ import { MockUserModule } from './user.mock';
     MockAuthModule,
     MockRecipeModule,
     MockUserModule,
+    MockReviewModule,
   ],
   providers: [
     {

--- a/test/mocks/review.mock.ts
+++ b/test/mocks/review.mock.ts
@@ -1,0 +1,83 @@
+import { JwtGuard } from '@/api/auth/guards/auth.guard';
+import { ReviewController } from '@/api/review/review.controller';
+import { UserRecipeReviewService } from '@/api/review/review.service';
+import { ERROR_CODES } from '@/common/constants/error-codes';
+import { CustomException } from '@/common/exceptions/custom-exception';
+import { UserRecipeReview } from '@/database/entity/user-recipe-review.entity';
+import { Module } from '@nestjs/common';
+import { MockJwtGuard } from './auth.mock';
+
+// completedRecipeId별로 호출 횟수를 추적
+const reviewCallCountMap = new Map<number, number>();
+
+const mockUserRecipeReviewService = {
+  createReview: async (userId: number, createDto: any) => {
+    // 사용자 검증
+    if (userId === 99999) {
+      throw new CustomException(ERROR_CODES.USER_NOT_FOUND);
+    }
+
+    const { completedRecipeId } = createDto;
+
+    // completedRecipeId별 호출 횟수 증가
+    const callCount = (reviewCallCountMap.get(completedRecipeId) || 0) + 1;
+    reviewCallCountMap.set(completedRecipeId, callCount);
+
+    // Mock 리뷰 생성
+    const review: UserRecipeReview = {
+      id: callCount, // 호출 횟수를 ID로 사용
+      userId,
+      userCompletedRecipeId: completedRecipeId,
+      tasteCode: createDto.tasteCode ?? null,
+      difficultyCode: createDto.difficultyCode ?? null,
+      experienceCode: createDto.experienceCode ?? null,
+      content: createDto.content ?? null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as UserRecipeReview;
+
+    return review;
+  },
+  getUserRecipeReviewPreparation: async (userId: number) => {
+    if (userId === 99999) {
+      throw new CustomException(ERROR_CODES.USER_NOT_FOUND);
+    }
+
+    return {
+      completionCount: 1,
+      completionMessage: '1번째 해먹기 완료!',
+      recipeName: '테스트 레시피',
+      recipeImageUrl: 'https://example.com/recipe.jpg',
+      tasteOptions: [
+        { code: 'R03001', codeName: '맛있어요' },
+        { code: 'R03002', codeName: '보통이에요' },
+        { code: 'R03003', codeName: '별로에요' },
+      ],
+      difficultyOptions: [
+        { code: 'R04001', codeName: '쉬워요' },
+        { code: 'R04002', codeName: '보통이에요' },
+        { code: 'R04003', codeName: '어려워요' },
+      ],
+      experienceOptions: [
+        { code: 'R05001', codeName: '첫 시도' },
+        { code: 'R05002', codeName: '여러 번 시도' },
+      ],
+    };
+  },
+};
+
+@Module({
+  controllers: [ReviewController],
+  providers: [
+    {
+      provide: UserRecipeReviewService,
+      useValue: mockUserRecipeReviewService,
+    },
+    {
+      provide: JwtGuard,
+      useClass: MockJwtGuard,
+    },
+  ],
+  exports: [UserRecipeReviewService],
+})
+export class MockReviewModule {}

--- a/test/mocks/review.mock.ts
+++ b/test/mocks/review.mock.ts
@@ -10,6 +10,9 @@ import { MockJwtGuard } from './auth.mock';
 // completedRecipeId별로 호출 횟수를 추적
 const reviewCallCountMap = new Map<number, number>();
 
+// 전역적으로 단조 증가하는 리뷰 ID 카운터
+let reviewIdSequence = 1;
+
 const mockUserRecipeReviewService = {
   createReview: async (userId: number, createDto: any) => {
     // 사용자 검증
@@ -25,7 +28,7 @@ const mockUserRecipeReviewService = {
 
     // Mock 리뷰 생성
     const review: UserRecipeReview = {
-      id: callCount, // 호출 횟수를 ID로 사용
+      id: reviewIdSequence++, // 전역적으로 단조 증가하는 ID
       userId,
       userCompletedRecipeId: completedRecipeId,
       tasteCode: createDto.tasteCode ?? null,
@@ -72,6 +75,7 @@ const mockUserRecipeReviewService = {
  */
 export function resetReviewMocks() {
   reviewCallCountMap.clear();
+  reviewIdSequence = 1;
 }
 
 @Module({

--- a/test/mocks/review.mock.ts
+++ b/test/mocks/review.mock.ts
@@ -66,6 +66,14 @@ const mockUserRecipeReviewService = {
   },
 };
 
+/**
+ * 테스트 격리를 위해 Mock 상태를 초기화하는 함수
+ * 각 E2E 테스트 파일의 afterAll에서 호출해야 합니다.
+ */
+export function resetReviewMocks() {
+  reviewCallCountMap.clear();
+}
+
 @Module({
   controllers: [ReviewController],
   providers: [

--- a/test/mocks/user.mock.ts
+++ b/test/mocks/user.mock.ts
@@ -395,6 +395,15 @@ const mockUserService = {
   },
 };
 
+/**
+ * 테스트 격리를 위해 Mock 상태를 초기화하는 함수
+ * 각 E2E 테스트 파일의 afterAll에서 호출해야 합니다.
+ */
+export function resetUserMocks() {
+  cookingStartCountMap.clear();
+  userServiceCookingStartCountMap.clear();
+}
+
 @Module({
   controllers: [UserController, UserRecipeArchiveController],
   providers: [

--- a/test/mocks/user.mock.ts
+++ b/test/mocks/user.mock.ts
@@ -8,6 +8,9 @@ import { CustomException } from '@/common/exceptions/custom-exception';
 import { Module } from '@nestjs/common';
 import { MockJwtGuard } from './auth.mock';
 
+// recipeId별로 호출 횟수를 추적하여 다른 completedRecipeId 반환
+const cookingStartCountMap = new Map<number, number>();
+
 const mockUserRecipeArchiveService = {
   createBookmark: async (_userId: number, createBookmarkDto: any) => {
     // 테스트 시나리오에 따라 다른 응답 반환
@@ -81,13 +84,13 @@ const mockUserRecipeArchiveService = {
       totalPages,
     };
   },
-  completeRecipe: async (userId: number, recipeId: number) => {
+  completeRecipe: async (userId: number, completedRecipeId: number) => {
     // 테스트 시나리오에 따라 다른 응답 반환
     if (userId === 99999) {
       throw new CustomException(ERROR_CODES.USER_NOT_FOUND); // 존재하지 않는 사용자 ID
     }
-    if (recipeId === 99999) {
-      throw new CustomException(ERROR_CODES.RECIPE_NOT_FOUND); // 존재하지 않는 레시피 ID
+    if (completedRecipeId === 99999) {
+      throw new CustomException(ERROR_CODES.RECIPE_COOKING_NOT_STARTED); // 존재하지 않는 완료 레시피 ID
     }
 
     // 성공적인 완료
@@ -103,8 +106,15 @@ const mockUserRecipeArchiveService = {
       throw new CustomException(ERROR_CODES.RECIPE_NOT_FOUND, 404);
     }
 
+    // recipeId별 호출 횟수 증가하여 다른 completedRecipeId 반환
+    const callCount = (cookingStartCountMap.get(recipeId) || 0) + 1;
+    cookingStartCountMap.set(recipeId, callCount);
+
+    // 첫 번째 호출: 100, 두 번째: 101, 세 번째: 102 등의 ID 반환
+    const completedRecipeId = 100 + callCount - 1;
+
     // 성공적인 요리 시작
-    return true;
+    return { completedRecipeId };
   },
   getCompletedRecipes: async (_userId: number, query: any) => {
     // Mock 데이터: 페이지네이션 응답 구조와 동일하게
@@ -222,7 +232,30 @@ const mockUserRecipeArchiveService = {
   },
 };
 
+// recipeId별로 호출 횟수를 추적하여 다른 completedRecipeId 반환 (UserService용)
+const userServiceCookingStartCountMap = new Map<number, number>();
+
 const mockUserService = {
+  startRecipeCooking: async (userId: number, recipeId: number) => {
+    // 테스트 시나리오에 따라 다른 응답 반환
+    if (userId === 99999) {
+      throw new CustomException(ERROR_CODES.USER_NOT_FOUND); // 존재하지 않는 사용자 ID
+    }
+    if (recipeId === 99999) {
+      // 테스트에서 404를 기대하므로 NOT_FOUND 상태 코드로 예외 발생
+      throw new CustomException(ERROR_CODES.RECIPE_NOT_FOUND, 404);
+    }
+
+    // recipeId별 호출 횟수 증가하여 다른 completedRecipeId 반환
+    const callCount = (userServiceCookingStartCountMap.get(recipeId) || 0) + 1;
+    userServiceCookingStartCountMap.set(recipeId, callCount);
+
+    // 첫 번째 호출: 100, 두 번째: 101, 세 번째: 102 등의 ID 반환
+    const completedRecipeId = 100 + callCount - 1;
+
+    // 성공적인 요리 시작
+    return { completedRecipeId };
+  },
   createBookmark: async (_userId: number, createBookmarkDto: any) => {
     // 테스트 시나리오에 따라 다른 응답 반환
     if (createBookmarkDto.recipeId === 99999) {
@@ -348,29 +381,16 @@ const mockUserService = {
       },
     ];
   },
-  completeRecipe: async (userId: number, recipeId: number) => {
+  completeRecipe: async (userId: number, completedRecipeId: number) => {
     // 테스트 시나리오에 따라 다른 응답 반환
     if (userId === 99999) {
       throw new CustomException(ERROR_CODES.USER_NOT_FOUND); // 존재하지 않는 사용자 ID
     }
-    if (recipeId === 99999) {
-      throw new CustomException(ERROR_CODES.RECIPE_NOT_FOUND); // 존재하지 않는 레시피 ID
+    if (completedRecipeId === 99999) {
+      throw new CustomException(ERROR_CODES.RECIPE_COOKING_NOT_STARTED); // 존재하지 않는 완료 레시피 ID
     }
 
     // 성공적인 완료
-    return true;
-  },
-  startRecipeCooking: async (userId: number, recipeId: number) => {
-    // 테스트 시나리오에 따라 다른 응답 반환
-    if (userId === 99999) {
-      throw new CustomException(ERROR_CODES.USER_NOT_FOUND); // 존재하지 않는 사용자 ID
-    }
-    if (recipeId === 99999) {
-      // 테스트에서 404를 기대하므로 NOT_FOUND 상태 코드로 예외 발생
-      throw new CustomException(ERROR_CODES.RECIPE_NOT_FOUND, 404);
-    }
-
-    // 성공적인 요리 시작
     return true;
   },
 };


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- startRecipeCooking API 반환값을 boolean에서 { completedRecipeId: number } 객체로 변경
- 같은 레시피를 여러 번 요리 시작/완료/후기 작성 가능한 기능 검증 및 테스트 추가

### ✨ 변경 내용  
---  
- [ ] (변경된 사항 요약) 
- [ ] (새로 추가된 기능이나 수정된 내용)  
- [ ] (리팩토링 및 코드 개선 사항)  

### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 동일한 레시피를 여러 번 시작하고 각 완료 기록에 대해 별도 후기 작성 가능

* **개선사항**
  * 레시피 요리 시작 시 생성된 completedRecipeId 객체 반환으로 완료·후기 연계 명확화
  * 완료 처리에서 완료 기록 ID를 직접 사용하도록 파라미터 명칭 및 응답 구조 정비

* **테스트**
  * 후기 흐름에 대한 단위 및 E2E 테스트 추가(다중 시작·다중 후기, 오류 시나리오 포함)
  * 테스트용 목(mock) 모듈 및 리셋 유틸 추가하여 격리된 검증 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->