### PR TITLE
feat: 레시피 상세 조회 반환값 수정: [기존] 레시피 건강 정보 -> [변경] 재료의 건강 정보를 랜덤으로 반환

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
         "@types/jest": "^29.5.2",
         "@types/node": "^20.3.1",
         "@types/supertest": "^6.0.0",
-        "@types/xlsx": "^0.0.35",
         "@typescript-eslint/eslint-plugin": "^8.26.1",
         "@typescript-eslint/parser": "^8.26.1",
         "eslint": "^8.57.1",
@@ -4010,13 +4009,6 @@
     },
     "node_modules/@types/validator": {
       "version": "13.15.2",
-      "license": "MIT"
-    },
-    "node_modules/@types/xlsx": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@types/xlsx/-/xlsx-0.0.35.tgz",
-      "integrity": "sha512-s0x3DYHZzOkxtjqOk/Nv1ezGzpbN7I8WX+lzlV/nFfTDOv7x4d8ZwGHcnaiB8UCx89omPsftQhS5II3jeWePxQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {

--- a/src/api/recipe/dto/get-recipe.dto.ts
+++ b/src/api/recipe/dto/get-recipe.dto.ts
@@ -204,11 +204,10 @@ export class GetRecipeResponseDto {
   steps: RecipeStepDto[];
 
   @ApiProperty({
-    description: '건강 포인트 배열',
-    type: [RecipeHealthPointDto],
-    isArray: true,
+    description: '랜덤 선택된 건강 포인트 (레시피 재료의 건강정보)',
+    type: RecipeHealthPointDto,
   })
-  healthPoints: RecipeHealthPointDto[];
+  healthPoint: RecipeHealthPointDto;
 
   @ApiProperty({
     description: '사용자의 북마크 여부',

--- a/src/api/recipe/recipe.controller.ts
+++ b/src/api/recipe/recipe.controller.ts
@@ -361,15 +361,12 @@ export class RecipeController {
           },
         },
       },
-      healthPoints: {
-        type: 'array',
-        items: {
-          type: 'object',
-          properties: {
-            content: {
-              type: 'string',
-              example: '고등어의 오메가3가 심혈관 건강에 도움을 줍니다',
-            },
+      healthPoint: {
+        type: 'object',
+        properties: {
+          content: {
+            type: 'string',
+            example: '고등어의 오메가3가 심혈관 건강에 도움을 줍니다',
           },
         },
       },

--- a/src/api/recipe/recipe.controller.ts
+++ b/src/api/recipe/recipe.controller.ts
@@ -377,6 +377,7 @@ export class RecipeController {
     },
   })
   @ApiErrorResponse(404, ERROR_CODES.RECIPE_NOT_FOUND)
+  @ApiErrorResponse(404, ERROR_CODES.INGREDIENT_HEALTH_INFO_NOT_FOUND)
   @ApiErrorResponse(401, ERROR_CODES.AUTH_REQUIRED)
   async getRecipe(
     @Param('id', ParseIntPipe) recipeId: number,

--- a/src/api/recipe/recipe.service.ts
+++ b/src/api/recipe/recipe.service.ts
@@ -301,6 +301,10 @@ export class RecipeService {
       };
     } catch (error) {
       this.logger.error('레시피 조회 중 에러 발생', error);
+      // CustomException인 경우 그대로 전파 (예: INGREDIENT_HEALTH_INFO_NOT_FOUND)
+      if (error instanceof CustomException) {
+        throw error;
+      }
       throw new CustomException(ERROR_CODES.RECIPE_GET_FAILED);
     }
   }
@@ -331,45 +335,37 @@ export class RecipeService {
   private async getRandomHealthPoint(
     ingredientIds: number[],
   ): Promise<RecipeHealthPointDto> {
-    try {
-      if (ingredientIds.length === 0) {
-        throw new CustomException(
-          ERROR_CODES.INGREDIENT_HEALTH_INFO_NOT_FOUND,
-          HttpStatus.NOT_FOUND,
-        );
-      }
-
-      // 레시피 재료의 건강정보 조회
-      const ingredientHealthInfos =
-        await this.ingredientHealthInfoRepository.find({
-          where: {
-            ingredientId: In(ingredientIds),
-          },
-        });
-
-      if (ingredientHealthInfos.length === 0) {
-        throw new CustomException(
-          ERROR_CODES.INGREDIENT_HEALTH_INFO_NOT_FOUND,
-          HttpStatus.NOT_FOUND,
-        );
-      }
-
-      // 랜덤 선택 (0 ~ length-1)
-      const randomIndex = Math.floor(
-        Math.random() * ingredientHealthInfos.length,
-      );
-      const selectedHealthInfo = ingredientHealthInfos[randomIndex];
-
-      return {
-        content: selectedHealthInfo.content,
-      };
-    } catch (error) {
-      this.logger.error('Failed to get random health point', error);
+    if (ingredientIds.length === 0) {
       throw new CustomException(
         ERROR_CODES.INGREDIENT_HEALTH_INFO_NOT_FOUND,
         HttpStatus.NOT_FOUND,
       );
     }
+
+    // 레시피 재료의 건강정보 조회
+    const ingredientHealthInfos =
+      await this.ingredientHealthInfoRepository.find({
+        where: {
+          ingredientId: In(ingredientIds),
+        },
+      });
+
+    if (ingredientHealthInfos.length === 0) {
+      throw new CustomException(
+        ERROR_CODES.INGREDIENT_HEALTH_INFO_NOT_FOUND,
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    // 랜덤 선택 (0 ~ length-1)
+    const randomIndex = Math.floor(
+      Math.random() * ingredientHealthInfos.length,
+    );
+    const selectedHealthInfo = ingredientHealthInfos[randomIndex];
+
+    return {
+      content: selectedHealthInfo.content,
+    };
   }
 
   private mapIngredientsWithOwnership(

--- a/src/api/recipe/recipe.service.ts
+++ b/src/api/recipe/recipe.service.ts
@@ -1,8 +1,10 @@
 import { CacheService } from '@/common/cache/cache.service';
 import { ERROR_CODES } from '@/common/constants/error-codes';
 import { CustomException } from '@/common/exceptions/custom-exception';
+import { HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { Condition } from '@/database/entity/condition.entity';
 import { Ingredient } from '@/database/entity/ingredient.entity';
+import { IngredientHealthInfo } from '@/database/entity/ingredient-health-info.entity';
 import { RecipeHealthPoint } from '@/database/entity/recipe-health-point.entity';
 import { RecipeImage } from '@/database/entity/recipe-image.entity';
 import { RecipeIngredient } from '@/database/entity/recipe-ingredient.entity';
@@ -14,7 +16,6 @@ import { Recipe } from '@/database/entity/recipe.entity';
 import { Seasoning } from '@/database/entity/seasoning.entity';
 import { Tool } from '@/database/entity/tool.entity';
 import { UserRecipeBookmark } from '@/database/entity/user-recipe-bookmark.entity';
-import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
@@ -22,6 +23,7 @@ import { CommonCodeService } from '../common-code/common-code.service';
 import { CreateRecipeDto } from './dto/create-recipe.dto';
 import {
   GetRecipeResponseDto,
+  RecipeHealthPointDto,
   RecipeIngredientDto,
 } from './dto/get-recipe.dto';
 
@@ -51,6 +53,8 @@ export class RecipeService {
     private readonly recipeStepRepository: Repository<RecipeStep>,
     @InjectRepository(RecipeHealthPoint)
     private readonly recipeHealthPointRepository: Repository<RecipeHealthPoint>,
+    @InjectRepository(IngredientHealthInfo)
+    private readonly ingredientHealthInfoRepository: Repository<IngredientHealthInfo>,
     @InjectRepository(Ingredient)
     private readonly ingredientRepository: Repository<Ingredient>,
     @InjectRepository(Seasoning)
@@ -211,7 +215,6 @@ export class RecipeService {
         recipeSeasonings,
         recipeTools,
         steps,
-        healthPoints,
         userBookmark,
       ] = await Promise.all([
         this.recipeImageRepository.find({ where: { recipeId } }),
@@ -219,7 +222,6 @@ export class RecipeService {
         this.recipeSeasoningRepository.find({ where: { recipeId } }),
         this.recipeToolRepository.find({ where: { recipeId } }),
         this.recipeStepRepository.find({ where: { recipeId } }),
-        this.recipeHealthPointRepository.find({ where: { recipeId } }),
         this.userRecipeBookmarkRepository.findOne({
           where: { userId, recipeId },
         }),
@@ -263,6 +265,8 @@ export class RecipeService {
         }));
 
       const userOwnedIngredients = await this.getUserOwnedIngredients(userId);
+      const healthPoint = await this.getRandomHealthPoint(ingredientIds);
+
       return {
         id: recipe.id,
         title: recipe.title,
@@ -292,9 +296,7 @@ export class RecipeService {
             orderNum: step.orderNum,
             summary: step.summary,
           })),
-        healthPoints: healthPoints.map((healthPoint) => ({
-          content: healthPoint.content,
-        })),
+        healthPoint,
         isBookmarked: !!userBookmark,
       };
     } catch (error) {
@@ -319,6 +321,54 @@ export class RecipeService {
     } catch (error) {
       this.logger.error('Failed to get cached ingredients', error);
       throw new CustomException(ERROR_CODES.RECIPE_GET_FAILED);
+    }
+  }
+
+  /**
+   * 레시피에 포함된 재료의 건강정보 중 랜덤으로 1개를 선택하여 반환합니다.
+   * 재료의 건강정보는 필수값이므로, 없을 경우 에러를 발생시킵니다.
+   */
+  private async getRandomHealthPoint(
+    ingredientIds: number[],
+  ): Promise<RecipeHealthPointDto> {
+    try {
+      if (ingredientIds.length === 0) {
+        throw new CustomException(
+          ERROR_CODES.INGREDIENT_HEALTH_INFO_NOT_FOUND,
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      // 레시피 재료의 건강정보 조회
+      const ingredientHealthInfos =
+        await this.ingredientHealthInfoRepository.find({
+          where: {
+            ingredientId: In(ingredientIds),
+          },
+        });
+
+      if (ingredientHealthInfos.length === 0) {
+        throw new CustomException(
+          ERROR_CODES.INGREDIENT_HEALTH_INFO_NOT_FOUND,
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      // 랜덤 선택 (0 ~ length-1)
+      const randomIndex = Math.floor(
+        Math.random() * ingredientHealthInfos.length,
+      );
+      const selectedHealthInfo = ingredientHealthInfos[randomIndex];
+
+      return {
+        content: selectedHealthInfo.content,
+      };
+    } catch (error) {
+      this.logger.error('Failed to get random health point', error);
+      throw new CustomException(
+        ERROR_CODES.INGREDIENT_HEALTH_INFO_NOT_FOUND,
+        HttpStatus.NOT_FOUND,
+      );
     }
   }
 

--- a/src/common/constants/error-codes.ts
+++ b/src/common/constants/error-codes.ts
@@ -85,6 +85,9 @@ export const ERROR_CODES = {
   // 건강 설문 오류
   HEALTH_SURVEY_NOT_ELIGIBLE: { code: 'E16001', message: '현재는 건강 설문을 작성할 수 없습니다.' },
 
+  // 건강정보 오류
+  INGREDIENT_HEALTH_INFO_NOT_FOUND: { code: 'E18001', message: '재료의 건강정보를 찾을 수 없습니다.' },
+
   // 계량 가이드 오류
   MEASUREMENT_GUIDE_ALREADY_EXISTS: { code: 'E17001', message: '이미 존재하는 계량 가이드입니다.' },
   MEASUREMENT_GUIDE_NOT_FOUND: { code: 'E17002', message: '계량 가이드를 찾을 수 없습니다.' },


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 레시피 상세 조회 반환값 수정: [기존] 레시피 건강 정보 -> [변경] 재료의 건강 정보를 랜덤으로 반환

### ✨ 변경 내용  
---  
- 레시피 상세조회의 반환값 변경

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 레시피 상세의 건강 포인트가 배열에서 단일 항목으로 변경되어 한눈에 보기 쉬운 정보 제공이 가능합니다.
  * 레시피 조회 시 재료 기반 건강 포인트를 랜덤으로 선택해 함께 표시합니다.

* **버그 수정**
  * 재료 건강정보가 없을 때의 명확한 오류 코드와 응답이 추가되어 오류 처리와 안정성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->