### PR TITLE
feat: 레시피 이미지 일괄 등록 API 추가

### DIFF
--- a/src/api/recipe/recipe.controller.ts
+++ b/src/api/recipe/recipe.controller.ts
@@ -753,4 +753,98 @@ export class RecipeController {
       errors: result.errors,
     });
   }
+
+  @Post('admin/import-recipe-images-excel')
+  @UseGuards(JwtGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('Authorization')
+  @ApiOperation({
+    summary: '[어드민] 엑셀 파일로 레시피 이미지 일괄 업데이트',
+    description: `엑셀 파일을 업로드하여 여러 레시피의 이미지를 한 번에 업데이트합니다. 
+파일의 컬럼은 다음 형식을 따라야 합니다: 
+- 레시피 ID
+- 레시피 이미지 (쉼표(,)로 구분된 여러 URL, 예: https://1,https://2,https://3) - 여러 개 등록 가능
+- {숫자}step 이미지 (동적으로 추가 가능, 예: 1step 이미지, 2step 이미지, 3step 이미지, ...) - 각 step마다 하나만 등록 가능
+
+레시피 이미지는 기존 이미지를 모두 삭제하고 새로 추가됩니다. 쉼표로 구분된 여러 개의 이미지를 등록할 수 있습니다.
+Step 이미지는 해당 step의 이미지만 업데이트됩니다. 각 step마다 하나의 이미지만 등록 가능하며, step 번호는 동적으로 처리되며 제한이 없습니다.
+
+스킵된 데이터가 있으면 엑셀 파일로 다운로드됩니다.`,
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: '엑셀 파일 (.xlsx, .xls, .xlsm)',
+        },
+      },
+    },
+  })
+  @ApiSuccessResponse('엑셀 레시피 이미지 일괄 업데이트 성공', {
+    type: 'object',
+    properties: {
+      message: {
+        type: 'string',
+        example:
+          '엑셀 파일에서 5개의 레시피 이미지가 성공적으로 업데이트되었습니다.',
+      },
+      updatedRecipeCount: { type: 'number', example: 5 },
+      skippedRecipeCount: { type: 'number', example: 2 },
+      errors: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            row: { type: 'number', example: 3 },
+            title: { type: 'string', example: '레시피 ID: 1' },
+            error: {
+              type: 'string',
+              example: '레시피 ID 1를 찾을 수 없습니다.',
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiErrorResponse(400, ERROR_CODES.VALIDATION_ERROR)
+  @ApiErrorResponse(401, ERROR_CODES.AUTH_REQUIRED)
+  @ApiErrorResponse(403, ERROR_CODES.AUTH_PERMISSION_DENIED)
+  @UseInterceptors(FileInterceptor('file'))
+  async importRecipeImagesFromExcel(
+    @UploadedFile() file: Express.Multer.File,
+    @Res() res: Response,
+  ): Promise<void> {
+    // 파일 검증
+    this.fileImportService.validateExcelFile(file);
+
+    const result = await this.fileImportService.importRecipeImagesFromExcel(
+      file.buffer,
+    );
+
+    // 스킵된 데이터가 있으면 엑셀 파일 다운로드
+    if (result.skippedExcelBuffer && result.skippedFileName) {
+      res.setHeader(
+        'Content-Type',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      );
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${result.skippedFileName}"`,
+      );
+      res.send(result.skippedExcelBuffer);
+      return;
+    }
+
+    // 스킵된 데이터가 없으면 일반 응답
+    res.json({
+      message: `엑셀 파일에서 ${result.updatedRecipeCount}개의 레시피 이미지가 성공적으로 업데이트되었습니다.`,
+      updatedRecipeCount: result.updatedRecipeCount,
+      skippedRecipeCount: result.skippedRecipeCount,
+      errors: result.errors,
+    });
+  }
 }

--- a/src/api/recipe/services/file-import.service.spec.ts
+++ b/src/api/recipe/services/file-import.service.spec.ts
@@ -10,6 +10,9 @@ import { Condition } from '@/database/entity/condition.entity';
 import { IngredientCategory } from '@/database/entity/ingredient-category.entity';
 import { IngredientHealthInfo } from '@/database/entity/ingredient-health-info.entity';
 import { Ingredient } from '@/database/entity/ingredient.entity';
+import { Recipe } from '@/database/entity/recipe.entity';
+import { RecipeImage } from '@/database/entity/recipe-image.entity';
+import { RecipeStep } from '@/database/entity/recipe-step.entity';
 import { Seasoning } from '@/database/entity/seasoning.entity';
 import { Tool } from '@/database/entity/tool.entity';
 
@@ -121,6 +124,18 @@ describe('FileImportService', () => {
         },
         {
           provide: getRepositoryToken(CommonCode),
+          useFactory: createRepositoryMock,
+        },
+        {
+          provide: getRepositoryToken(Recipe),
+          useFactory: createRepositoryMock,
+        },
+        {
+          provide: getRepositoryToken(RecipeImage),
+          useFactory: createRepositoryMock,
+        },
+        {
+          provide: getRepositoryToken(RecipeStep),
           useFactory: createRepositoryMock,
         },
         {

--- a/src/api/recipe/services/file-import.service.ts
+++ b/src/api/recipe/services/file-import.service.ts
@@ -1031,11 +1031,20 @@ export class FileImportService {
           }
 
           // 트랜잭션으로 이미지 업데이트
-          await this.updateRecipeImages(
+          const warnings = await this.updateRecipeImages(
             recipeId,
             recipeImageUrls,
             stepImageMap,
           );
+
+          // Step을 찾지 못한 경우 경고를 에러로 추가
+          if (warnings.length > 0) {
+            errors.push({
+              row: rowNumber,
+              title: `레시피 ID: ${recipeId}`,
+              error: `일부 step 이미지를 업데이트하지 못했습니다: ${warnings.join(', ')}`,
+            });
+          }
 
           updatedRecipeCount++;
           this.logger.log(
@@ -1098,8 +1107,8 @@ export class FileImportService {
       // 전체 임포트 과정에서 예상치 못한 에러 발생 시
       this.logger.error('레시피 이미지 엑셀 파싱 중 오류 발생', error);
       throw new CustomException({
-        code: ERROR_CODES.RECIPE_CREATE_FAILED.code,
-        message: `레시피 이미지 엑셀 파싱 실패: ${error.message}`,
+        code: ERROR_CODES.VALIDATION_ERROR.code,
+        message: `레시피 이미지 업데이트 실패: ${error.message}`,
       });
     }
   }
@@ -1112,13 +1121,15 @@ export class FileImportService {
    * @param recipeId 레시피 ID
    * @param recipeImageUrls 레시피 이미지 URL 배열 (쉼표로 구분된 여러 개의 이미지, 빈 배열이면 본문 이미지는 업데이트하지 않음)
    * @param stepImageMap Step 번호와 이미지 URL 맵 (각 step마다 하나의 이미지만)
+   * @returns Step을 찾지 못한 경우의 경고 메시지 배열
    */
   @Transactional()
   private async updateRecipeImages(
     recipeId: number,
     recipeImageUrls: Array<{ imageUrl: string }>,
     stepImageMap: Map<number, string>,
-  ): Promise<void> {
+  ): Promise<string[]> {
+    const warnings: string[] = [];
     // 레시피 본문 이미지 업데이트 (이미지가 제공된 경우에만)
     if (recipeImageUrls.length > 0) {
       // 기존 레시피 이미지 삭제
@@ -1145,12 +1156,14 @@ export class FileImportService {
           step.imageUrl = imageUrl;
           await this.recipeStepRepository.save(step);
         } else {
-          this.logger.warn(
-            `레시피 ${recipeId}의 ${stepNum}단계를 찾을 수 없습니다.`,
-          );
+          const warning = `${stepNum}단계를 찾을 수 없습니다.`;
+          this.logger.warn(`레시피 ${recipeId}의 ${warning}`);
+          warnings.push(warning);
         }
       }
     }
+
+    return warnings;
   }
 
   /**

--- a/src/api/recipe/services/file-import.service.ts
+++ b/src/api/recipe/services/file-import.service.ts
@@ -973,14 +973,23 @@ export class FileImportService {
                 String(value).trim() !== '',
             );
 
-            if (hasAnyData) {
-              // 데이터는 있지만 레시피 ID가 없는 경우 로그
-              this.logger.warn(
-                `행 ${rowNumber}: 레시피 ID가 없거나 유효하지 않아 스킵합니다.`,
-              );
-            } else {
+            if (!hasAnyData) {
               // 완전히 빈 행인 경우 조용히 스킵
               this.logger.log(`행 ${rowNumber}: 빈 행으로 스킵합니다.`);
+              continue;
+            }
+
+            // 데이터는 있지만 레시피 ID가 없는 경우 에러로 집계
+            const validationError =
+              FileImportValidator.validateRecipeImageRequiredFields(
+                row,
+                rowNumber,
+                null,
+              );
+            if (validationError) {
+              errors.push(validationError);
+              skippedRows.push({ row, rowNumber });
+              skippedRecipeCount++;
             }
             continue;
           }
@@ -1097,11 +1106,11 @@ export class FileImportService {
 
   /**
    * 레시피 이미지를 업데이트합니다.
-   * 기존 레시피 이미지는 삭제하고 새로운 이미지를 추가합니다. (쉼표로 구분된 여러 개의 이미지 등록 가능)
+   * 레시피 본문 이미지가 제공된 경우에만 기존 이미지를 삭제하고 새로운 이미지를 추가합니다.
    * Step 이미지는 해당 step의 이미지만 업데이트합니다. (각 step마다 하나의 이미지만 등록 가능)
    *
    * @param recipeId 레시피 ID
-   * @param recipeImageUrls 레시피 이미지 URL 배열 (쉼표로 구분된 여러 개의 이미지)
+   * @param recipeImageUrls 레시피 이미지 URL 배열 (쉼표로 구분된 여러 개의 이미지, 빈 배열이면 본문 이미지는 업데이트하지 않음)
    * @param stepImageMap Step 번호와 이미지 URL 맵 (각 step마다 하나의 이미지만)
    */
   @Transactional()
@@ -1110,11 +1119,12 @@ export class FileImportService {
     recipeImageUrls: Array<{ imageUrl: string }>,
     stepImageMap: Map<number, string>,
   ): Promise<void> {
-    // 기존 레시피 이미지 삭제
-    await this.recipeImageRepository.delete({ recipeId });
-
-    // 새로운 레시피 이미지 추가
+    // 레시피 본문 이미지 업데이트 (이미지가 제공된 경우에만)
     if (recipeImageUrls.length > 0) {
+      // 기존 레시피 이미지 삭제
+      await this.recipeImageRepository.delete({ recipeId });
+
+      // 새로운 레시피 이미지 추가
       const recipeImages = recipeImageUrls.map((imageDto) =>
         this.recipeImageRepository.create({
           recipeId,

--- a/src/api/recipe/services/file-import.service.ts
+++ b/src/api/recipe/services/file-import.service.ts
@@ -6,11 +6,15 @@ import { Condition } from '@/database/entity/condition.entity';
 import { IngredientCategory } from '@/database/entity/ingredient-category.entity';
 import { IngredientHealthInfo } from '@/database/entity/ingredient-health-info.entity';
 import { Ingredient } from '@/database/entity/ingredient.entity';
+import { RecipeImage } from '@/database/entity/recipe-image.entity';
+import { RecipeStep } from '@/database/entity/recipe-step.entity';
+import { Recipe } from '@/database/entity/recipe.entity';
 import { Seasoning } from '@/database/entity/seasoning.entity';
 import { Tool } from '@/database/entity/tool.entity';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
+import { Transactional } from 'typeorm-transactional';
 import * as XLSX from 'xlsx';
 import { DIVISION, EXCEL_SHEET_NAME } from '../constants/file-import.constants';
 import { CreateRecipeDto } from '../dto/create-recipe.dto';
@@ -18,6 +22,7 @@ import { RecipeService } from '../recipe.service';
 import { RecipeError } from '../types/file-import.types';
 import { ExcelNormalizerUtil } from '../utils/excel-normalizer.util';
 import { IngredientSeasoningParserUtil } from '../utils/ingredient-seasoning-parser.util';
+import { RecipeImageParserUtil } from '../utils/recipe-image-parser.util';
 import { RecipeParserUtil } from '../utils/recipe-parser.util';
 import { FileImportValidator } from '../validators/file-import.validator';
 
@@ -44,6 +49,12 @@ export class FileImportService {
     private readonly conditionRepository: Repository<Condition>,
     @InjectRepository(CommonCode)
     private readonly commonCodeRepository: Repository<CommonCode>,
+    @InjectRepository(Recipe)
+    private readonly recipeRepository: Repository<Recipe>,
+    @InjectRepository(RecipeImage)
+    private readonly recipeImageRepository: Repository<RecipeImage>,
+    @InjectRepository(RecipeStep)
+    private readonly recipeStepRepository: Repository<RecipeStep>,
     private readonly recipeService: RecipeService,
   ) {}
 
@@ -908,5 +919,315 @@ export class FileImportService {
         message: `재료/양념 엑셀 파싱 실패: ${error.message}`,
       });
     }
+  }
+
+  // ============================================================================
+  // 레시피 이미지 업데이트 메서드
+  // ============================================================================
+
+  /**
+   * 엑셀 파일을 파싱하여 레시피 이미지를 업데이트합니다.
+   * 엑셀 파일을 읽어서 각 행의 데이터를 파싱하고 레시피의 이미지를 업데이트합니다.
+   * 에러가 발생한 행은 스킵하고, 스킵된 데이터는 별도의 엑셀 파일로 저장합니다.
+   *
+   * @param buffer 엑셀 파일의 버퍼 데이터
+   * @returns 레시피 이미지 업데이트 결과 (업데이트된 레시피 수, 스킵된 레시피 수, 에러 목록, 스킵된 데이터 엑셀 파일)
+   */
+  async importRecipeImagesFromExcel(buffer: Buffer): Promise<{
+    updatedRecipeCount: number;
+    skippedRecipeCount: number;
+    errors: RecipeError[];
+    skippedExcelBuffer: Buffer | null;
+    skippedFileName: string | null;
+  }> {
+    try {
+      // 엑셀 파일을 파싱하여 레시피 데이터 배열로 변환
+      const records = this.parseExcelFile(buffer) || [];
+      this.logger.log(
+        `엑셀 파일에서 ${records.length}개의 레시피 이미지 데이터를 찾았습니다.`,
+      );
+
+      // 임포트 결과 추적 변수 초기화
+      let updatedRecipeCount = 0; // 성공적으로 업데이트된 레시피 수
+      let skippedRecipeCount = 0; // 스킵된 레시피 수
+      const errors: RecipeError[] = []; // 에러 목록
+      const skippedRows: Array<{
+        row: Record<string, any>;
+        rowNumber: number;
+      }> = []; // 스킵된 행 데이터 (엑셀 파일 생성용)
+
+      // 각 행을 순회하면서 레시피 이미지 업데이트 시도
+      for (const [index, row] of records.entries()) {
+        const rowNumber = index + 2; // 엑셀 행 번호 (헤더 행 포함, 2부터 시작)
+        try {
+          // 레시피 ID 파싱
+          const recipeId = RecipeImageParserUtil.parseRecipeId(row);
+
+          // 헤더 행 및 빈 행 필터링: 레시피 ID가 없거나 유효하지 않으면 스킵
+          if (!recipeId) {
+            // 빈 행 체크: 모든 컬럼이 비어있는지 확인
+            const hasAnyData = Object.values(row).some(
+              (value) =>
+                value !== null &&
+                value !== undefined &&
+                String(value).trim() !== '',
+            );
+
+            if (hasAnyData) {
+              // 데이터는 있지만 레시피 ID가 없는 경우 로그
+              this.logger.warn(
+                `행 ${rowNumber}: 레시피 ID가 없거나 유효하지 않아 스킵합니다.`,
+              );
+            } else {
+              // 완전히 빈 행인 경우 조용히 스킵
+              this.logger.log(`행 ${rowNumber}: 빈 행으로 스킵합니다.`);
+            }
+            continue;
+          }
+
+          // 레시피 찾기
+          const recipe = await this.recipeRepository.findOne({
+            where: { id: recipeId },
+          });
+
+          // 필수 필드 검증
+          const validationError =
+            FileImportValidator.validateRecipeImageRequiredFields(
+              row,
+              rowNumber,
+              recipe,
+            );
+          if (validationError) {
+            errors.push(validationError);
+            skippedRows.push({ row, rowNumber });
+            skippedRecipeCount++;
+            continue;
+          }
+
+          // 레시피 이미지 파싱 (쉼표로 구분된 URL 리스트)
+          const recipeImagesText = row[EXCEL_COLUMNS.RECIPE_IMAGE.IMAGES] || '';
+          const recipeImageUrls =
+            RecipeImageParserUtil.parseRecipeImages(recipeImagesText || '') ||
+            [];
+
+          // Step 이미지 파싱 (동적으로 처리: 1step 이미지, 2step 이미지, ...)
+          const stepImageMap = RecipeImageParserUtil.parseStepImages(row);
+
+          // 이미지가 하나도 없는 행은 스킵 (데이터가 없는 빈 행)
+          if (recipeImageUrls.length === 0 && stepImageMap.size === 0) {
+            this.logger.log(
+              `행 ${rowNumber}: 레시피 ID ${recipeId}는 이미지 데이터가 없어 스킵합니다.`,
+            );
+            continue;
+          }
+
+          // 트랜잭션으로 이미지 업데이트
+          await this.updateRecipeImages(
+            recipeId,
+            recipeImageUrls,
+            stepImageMap,
+          );
+
+          updatedRecipeCount++;
+          this.logger.log(
+            `레시피 ${recipeId} 이미지 업데이트 완료: ${recipe.title}`,
+          );
+        } catch (error) {
+          // 에러 발생 시 처리
+          const errorMessage = error?.message || '알 수 없는 오류';
+          if (
+            !errors.some(
+              (e) => e && e.row === rowNumber && e.error === errorMessage,
+            )
+          ) {
+            const recipeId = RecipeImageParserUtil.parseRecipeId(row);
+            errors.push({
+              row: rowNumber,
+              title: recipeId ? `레시피 ID: ${recipeId}` : '(제목 없음)',
+              error: errorMessage,
+            });
+          }
+          skippedRows.push({ row, rowNumber });
+          skippedRecipeCount++;
+          this.logger.error(`행 ${rowNumber} 처리 실패`, error);
+        }
+      }
+
+      // 임포트 완료 로그
+      this.logger.log(
+        `총 ${updatedRecipeCount}개의 레시피 이미지가 업데이트되었습니다.`,
+      );
+      this.logger.log(`${skippedRecipeCount}개의 레시피가 건너뛰었습니다.`);
+
+      // 스킵된 데이터가 있으면 엑셀 파일 생성
+      let skippedExcelBuffer: Buffer | null = null;
+      let skippedFileName: string | null = null;
+
+      // undefined 값 제거
+      const validErrors = errors.filter((err) => err != null);
+
+      if (skippedRows.length > 0) {
+        // 스킵된 레시피 데이터를 엑셀 파일로 변환
+        skippedExcelBuffer = this.createSkippedRecipeImageExcel(
+          skippedRows,
+          validErrors,
+        );
+        // 타임스탬프를 포함한 파일명 생성
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        skippedFileName = `skipped_recipe_images_${timestamp}.xlsx`;
+      }
+
+      // 임포트 결과 반환
+      return {
+        updatedRecipeCount,
+        skippedRecipeCount,
+        errors: validErrors,
+        skippedExcelBuffer,
+        skippedFileName,
+      };
+    } catch (error) {
+      // 전체 임포트 과정에서 예상치 못한 에러 발생 시
+      this.logger.error('레시피 이미지 엑셀 파싱 중 오류 발생', error);
+      throw new CustomException({
+        code: ERROR_CODES.RECIPE_CREATE_FAILED.code,
+        message: `레시피 이미지 엑셀 파싱 실패: ${error.message}`,
+      });
+    }
+  }
+
+  /**
+   * 레시피 이미지를 업데이트합니다.
+   * 기존 레시피 이미지는 삭제하고 새로운 이미지를 추가합니다. (쉼표로 구분된 여러 개의 이미지 등록 가능)
+   * Step 이미지는 해당 step의 이미지만 업데이트합니다. (각 step마다 하나의 이미지만 등록 가능)
+   *
+   * @param recipeId 레시피 ID
+   * @param recipeImageUrls 레시피 이미지 URL 배열 (쉼표로 구분된 여러 개의 이미지)
+   * @param stepImageMap Step 번호와 이미지 URL 맵 (각 step마다 하나의 이미지만)
+   */
+  @Transactional()
+  private async updateRecipeImages(
+    recipeId: number,
+    recipeImageUrls: Array<{ imageUrl: string }>,
+    stepImageMap: Map<number, string>,
+  ): Promise<void> {
+    // 기존 레시피 이미지 삭제
+    await this.recipeImageRepository.delete({ recipeId });
+
+    // 새로운 레시피 이미지 추가
+    if (recipeImageUrls.length > 0) {
+      const recipeImages = recipeImageUrls.map((imageDto) =>
+        this.recipeImageRepository.create({
+          recipeId,
+          imageUrl: imageDto.imageUrl,
+        }),
+      );
+      await this.recipeImageRepository.save(recipeImages);
+    }
+
+    // Step 이미지 업데이트
+    if (stepImageMap.size > 0) {
+      for (const [stepNum, imageUrl] of stepImageMap.entries()) {
+        const step = await this.recipeStepRepository.findOne({
+          where: { recipeId, orderNum: stepNum },
+        });
+
+        if (step) {
+          step.imageUrl = imageUrl;
+          await this.recipeStepRepository.save(step);
+        } else {
+          this.logger.warn(
+            `레시피 ${recipeId}의 ${stepNum}단계를 찾을 수 없습니다.`,
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * 스킵된 레시피 이미지 데이터를 엑셀 파일로 변환합니다.
+   * step 이미지 컬럼을 동적으로 찾아서 포함시킵니다.
+   *
+   * @param skippedRows 스킵된 레시피 행 데이터 배열
+   * @param errors 각 행의 에러 정보 배열
+   * @returns 생성된 엑셀 파일 버퍼 (스킵된 행이 없으면 null)
+   */
+  private createSkippedRecipeImageExcel(
+    skippedRows: Array<{
+      row: Record<string, any>;
+      rowNumber: number;
+    }>,
+    errors: RecipeError[],
+  ): Buffer | null {
+    // 스킵된 행이 없으면 null 반환
+    if (skippedRows.length === 0) {
+      return null;
+    }
+
+    // 에러 정보를 행 번호로 매핑
+    const errorMap = new Map<number, string>();
+    errors.forEach((err) => {
+      if (err && err.row !== undefined) {
+        errorMap.set(err.row, err.error);
+      }
+    });
+
+    // 모든 스킵된 행에서 컬럼명 수집 (step 이미지 컬럼 포함)
+    const allColumns = new Set<string>();
+    skippedRows.forEach((item) => {
+      if (item && item.row) {
+        Object.keys(item.row).forEach((key) => {
+          allColumns.add(key);
+        });
+      }
+    });
+
+    // 기본 컬럼 순서 정의
+    const baseColumns = [
+      EXCEL_COLUMNS.RECIPE_IMAGE.ID,
+      EXCEL_COLUMNS.RECIPE_IMAGE.IMAGES,
+    ];
+
+    // step 이미지 컬럼만 추출하여 정렬
+    const stepImageColumns = Array.from(allColumns)
+      .filter((col) => /^\d+step\s*이미지$/.test(col))
+      .sort((a, b) => {
+        // 컬럼명에서 숫자 추출하여 단계 번호로 정렬
+        const numA = parseInt(a.match(/^(\d+)/)?.[1] || '0', 10);
+        const numB = parseInt(b.match(/^(\d+)/)?.[1] || '0', 10);
+        return numA - numB;
+      });
+
+    // 스킵 이유를 포함한 데이터 준비
+    const data = skippedRows
+      .filter((item) => item && item.row)
+      .map((item) => {
+        const row = item.row;
+        const rowNumber = item.rowNumber;
+        const error = errorMap.get(rowNumber) || '';
+
+        const rowData: Record<string, any> = {};
+        // 기본 컬럼 추가
+        for (const col of baseColumns) {
+          rowData[col] = row[col] || '';
+        }
+        // step 이미지 컬럼 추가
+        for (const col of stepImageColumns) {
+          rowData[col] = row[col] || '';
+        }
+        // 스킵 이유 추가
+        rowData[EXCEL_SHEET_NAME.SKIP_REASON_COLUMN] = error;
+
+        return rowData;
+      });
+
+    // 엑셀 파일 생성
+    const worksheet = XLSX.utils.json_to_sheet(data);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, EXCEL_SHEET_NAME.SKIPPED);
+
+    // 버퍼로 변환하여 반환
+    return Buffer.from(
+      XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' }),
+    );
   }
 }

--- a/src/api/recipe/utils/recipe-image-parser.util.ts
+++ b/src/api/recipe/utils/recipe-image-parser.util.ts
@@ -1,0 +1,94 @@
+import { EXCEL_COLUMNS } from '@/common/constants/excel-columns.constants';
+
+/**
+ * 레시피 이미지 파싱 관련 유틸리티 함수
+ */
+export class RecipeImageParserUtil {
+  /**
+   * 레시피 이미지 URL 문자열을 파싱합니다.
+   * 쉼표로 구분된 이미지 URL 문자열을 객체 배열로 변환합니다.
+   *
+   * @param imagesText 이미지 URL 문자열 (쉼표로 구분)
+   * @returns 이미지 URL 객체 배열
+   *
+   * @example
+   * parseRecipeImages("https://image1.jpg, https://image2.jpg")
+   * // -> [{ imageUrl: "https://image1.jpg" }, { imageUrl: "https://image2.jpg" }]
+   */
+  static parseRecipeImages(imagesText: string): Array<{ imageUrl: string }> {
+    if (!imagesText || !imagesText.trim()) {
+      return [];
+    }
+
+    // 쉼표로 분리, 공백 제거, 빈 문자열 제거
+    const imageUrls = imagesText
+      .split(',')
+      .map((url) => url.trim())
+      .filter((url) => url.length > 0);
+
+    // 이미지 URL 객체 배열로 변환
+    return imageUrls.map((imageUrl) => ({ imageUrl }));
+  }
+
+  /**
+   * 엑셀 행 데이터에서 레시피 ID를 파싱합니다.
+   *
+   * @param row 엑셀 행 데이터
+   * @returns 레시피 ID (파싱 실패 시 null)
+   */
+  static parseRecipeId(row: Record<string, any>): number | null {
+    const recipeIdText = row[EXCEL_COLUMNS.RECIPE_IMAGE.ID] || '';
+    if (!recipeIdText) {
+      return null;
+    }
+
+    const trimmed = String(recipeIdText).trim();
+
+    // 헤더 행 체크: "레시피 ID"라는 문자열이면 헤더 행으로 간주
+    if (trimmed === EXCEL_COLUMNS.RECIPE_IMAGE.ID) {
+      return null;
+    }
+
+    // 숫자로 파싱
+    const recipeId = parseInt(trimmed, 10);
+
+    // NaN이거나 0 이하면 null 반환 (헤더 행 또는 잘못된 데이터)
+    if (isNaN(recipeId) || recipeId <= 0) {
+      return null;
+    }
+
+    return recipeId;
+  }
+
+  /**
+   * 엑셀 행 데이터에서 step 이미지를 파싱합니다.
+   * 동적으로 생성된 step 이미지 컬럼들({숫자}step 이미지)을 찾아서 Map으로 변환합니다.
+   *
+   * @param row 엑셀 행 데이터
+   * @returns Step 번호와 이미지 URL 맵 (각 step마다 하나의 이미지만)
+   *
+   * @example
+   * parseStepImages({ "1step 이미지": "https://1.jpg", "2step 이미지": "https://2.jpg" })
+   * // -> Map(2) { 1 => "https://1.jpg", 2 => "https://2.jpg" }
+   */
+  static parseStepImages(row: Record<string, any>): Map<number, string> {
+    const stepImageMap = new Map<number, string>();
+
+    // 엑셀의 모든 컬럼을 순회하여 step 이미지 컬럼 찾기
+    for (const [columnName, value] of Object.entries(row)) {
+      // 값이 없거나 빈 값이면 스킵
+      if (value === null || value === undefined) continue;
+      const valueStr = String(value).trim();
+      if (!valueStr) continue;
+
+      // {숫자}step 이미지 패턴 찾기 (예: "1step 이미지", "2step 이미지")
+      const stepImageMatch = columnName.match(/^(\d+)step\s*이미지$/);
+      if (stepImageMatch) {
+        const stepNum = parseInt(stepImageMatch[1], 10);
+        stepImageMap.set(stepNum, valueStr);
+      }
+    }
+
+    return stepImageMap;
+  }
+}

--- a/src/api/recipe/validators/file-import.validator.ts
+++ b/src/api/recipe/validators/file-import.validator.ts
@@ -3,6 +3,7 @@ import { EXCEL_COLUMNS } from '@/common/constants/excel-columns.constants';
 import { CustomException } from '@/common/exceptions/custom-exception';
 import { Condition } from '@/database/entity/condition.entity';
 import { Ingredient } from '@/database/entity/ingredient.entity';
+import { Recipe } from '@/database/entity/recipe.entity';
 import { Seasoning } from '@/database/entity/seasoning.entity';
 import { DIVISION } from '../constants/file-import.constants';
 import { RecipeError } from '../types/file-import.types';
@@ -206,6 +207,42 @@ export class FileImportValidator {
       if (existingSeasoning) {
         return `양념 "${name}"이 이미 존재합니다.`;
       }
+    }
+
+    return null; // 모든 검증 통과
+  }
+
+  /**
+   * 레시피 이미지 행 데이터의 필수 필드를 검증합니다.
+   *
+   * @param row 엑셀 행 데이터
+   * @param rowNumber 행 번호 (에러 메시지용)
+   * @param recipe 레시피 엔티티 (존재 여부 확인용, null이면 레시피를 찾을 수 없음)
+   * @returns 검증 결과 (통과 시 null, 실패 시 RecipeError 반환)
+   */
+  static validateRecipeImageRequiredFields(
+    row: Record<string, any>,
+    rowNumber: number,
+    recipe: Recipe | null,
+  ): RecipeError | null {
+    // 레시피 ID 검증
+    const recipeIdText = row[EXCEL_COLUMNS.RECIPE_IMAGE.ID] || '';
+    if (!recipeIdText || !String(recipeIdText).trim()) {
+      return {
+        row: rowNumber,
+        title: '',
+        error: '레시피 ID가 없거나 유효하지 않습니다.',
+      };
+    }
+
+    // 레시피 존재 여부 검증
+    if (!recipe) {
+      const recipeId = parseInt(String(recipeIdText).trim(), 10);
+      return {
+        row: rowNumber,
+        title: `레시피 ID: ${recipeId}`,
+        error: `레시피 ID ${recipeId}를 찾을 수 없습니다.`,
+      };
     }
 
     return null; // 모든 검증 통과

--- a/src/common/constants/excel-columns.constants.ts
+++ b/src/common/constants/excel-columns.constants.ts
@@ -23,4 +23,10 @@ export const EXCEL_COLUMNS = {
     SEASONINGS: '양념',
     // step 컬럼은 동적으로 처리: {숫자}step 요약, {숫자}step, {숫자}step 이미지 형식 (예: 1step 요약, 1step, 1step 이미지, 2step 요약, 2step, 2step 이미지, ...)
   },
+  // 레시피 이미지 업데이트 엑셀 컬럼명
+  RECIPE_IMAGE: {
+    ID: '레시피 ID',
+    IMAGES: '레시피 이미지',
+    // step 이미지 컬럼은 동적으로 처리: {숫자}step 이미지 형식 (예: 1step 이미지, 2step 이미지, ...)
+  },
 } as const;


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 레시피 이미지 일괄 등록 API 추가

### ✨ 변경 내용  
---  
- [ ] (변경된 사항 요약) 
- [ ] (새로 추가된 기능이나 수정된 내용)  
- [ ] (리팩토링 및 코드 개선 사항)  

### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 엑셀 업로드로 레시피 이미지 대량 일괄 업데이트 지원 — 결과 요약(업데이트 수·건너뜀 수·오류) 반환 및 건너뜀 항목 엑셀 파일 다운로드 제공.
  * 엑셀 파싱 및 검증 개선으로 본문·단계 이미지 컬럼을 동적 처리하고 오류 추적·로깅 강화.
* **테스트**
  * 파일 임포트 관련 테스트에 필요한 엔티티 레포지토리 목 제공 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->