### PR TITLE
feat: 재료 건강 정보 관련 로직 수정

### DIFF
--- a/src/api/recipe/recipe.service.ts
+++ b/src/api/recipe/recipe.service.ts
@@ -330,7 +330,7 @@ export class RecipeService {
 
   /**
    * 레시피에 포함된 재료의 건강정보 중 랜덤으로 1개를 선택하여 반환합니다.
-   * 재료의 건강정보는 필수값이므로, 없을 경우 에러를 발생시킵니다.
+   * 건강 정보가 없을 경우, 기본 메시지를 반환합니다.
    */
   private async getRandomHealthPoint(
     ingredientIds: number[],
@@ -350,18 +350,19 @@ export class RecipeService {
         },
       });
 
-    if (ingredientHealthInfos.length === 0) {
-      throw new CustomException(
-        ERROR_CODES.INGREDIENT_HEALTH_INFO_NOT_FOUND,
-        HttpStatus.NOT_FOUND,
-      );
+    const validHealthInfos = ingredientHealthInfos.filter(
+      (info) => info.content && info.content.trim().length > 0,
+    );
+
+    if (validHealthInfos.length === 0) {
+      return {
+        content:
+          '그래도 가끔은 속세의 맛도 필요하잖아요...? 오늘만큼은 괜찮아요!',
+      };
     }
 
-    // 랜덤 선택 (0 ~ length-1)
-    const randomIndex = Math.floor(
-      Math.random() * ingredientHealthInfos.length,
-    );
-    const selectedHealthInfo = ingredientHealthInfos[randomIndex];
+    const randomIndex = Math.floor(Math.random() * validHealthInfos.length);
+    const selectedHealthInfo = validHealthInfos[randomIndex];
 
     return {
       content: selectedHealthInfo.content,

--- a/src/database/entity/ingredient-health-info.entity.ts
+++ b/src/database/entity/ingredient-health-info.entity.ts
@@ -13,6 +13,7 @@ export class IngredientHealthInfo extends CommonEntity {
   @Column({
     type: 'text',
     comment: '건강 정보 내용',
+    nullable: true,
   })
-  content: string;
+  content: string | null;
 }

--- a/src/database/migrations/20251103-UpdateIngredientHealthInfo.ts
+++ b/src/database/migrations/20251103-UpdateIngredientHealthInfo.ts
@@ -1,0 +1,35 @@
+import { QueryRunner, TableColumn } from 'typeorm';
+
+module.exports = class Migration20251103190105 {
+  async up(queryRunner: QueryRunner) {
+    await queryRunner.changeColumn(
+      'ingredient_health_infos',
+      'content',
+      new TableColumn({
+        name: 'content',
+        type: 'text',
+        isNullable: true,
+        comment: '건강 정보 내용',
+      }),
+    );
+  }
+
+  async down(queryRunner: QueryRunner) {
+    // 롤백: NULL 값이 있으면 빈 문자열로 변경 후 NOT NULL로 복원
+    await queryRunner.query(
+      "UPDATE ingredient_health_infos SET content = '' WHERE content IS NULL;",
+    );
+
+    // content 컬럼을 다시 NOT NULL로 변경
+    await queryRunner.changeColumn(
+      'ingredient_health_infos',
+      'content',
+      new TableColumn({
+        name: 'content',
+        type: 'text',
+        isNullable: false,
+        comment: '건강 정보 내용',
+      }),
+    );
+  }
+};


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- P재료 건강 정보 관련 로직 수정

### ✨ 변경 내용  
---  
- [ ] 재료 건강 정보 테이블의 건강 정보 속성을 nullable하게 수정
- [ ] 레시피 상세 조회 시, 재료 건강 정보를 가져오는 부분에서 기본값 설정 ('그래도 가끔은 속세의 맛도 필요하잖아요...? 오늘만큼은 괜찮아요!')

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 건강 정보를 사용할 수 없을 때 오류를 표시하는 대신 친화적인 기본 메시지를 반환하도록 개선했습니다.

* **개선사항**
  * 데이터 처리 안정성을 강화하여 엣지 케이스를 더 잘 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->