### PR TITLE
feat: 못 먹는 음식 목록 조회(온보딩) 수정 (반환값에 카테고리 네임 추가)

### DIFF
--- a/src/api/ingredient/dto/get-restricted-ingredients.dto.ts
+++ b/src/api/ingredient/dto/get-restricted-ingredients.dto.ts
@@ -16,6 +16,13 @@ export class RestrictedIngredientItemDto {
   name: string;
 
   @ApiProperty({
+    type: String,
+    description: '카테고리 이름',
+    example: '해산물류',
+  })
+  categoryName: string;
+
+  @ApiProperty({
     type: Boolean,
     description: '사용자가 선택한 못먹는 재료 여부',
     example: false,

--- a/src/api/ingredient/ingredient.service.ts
+++ b/src/api/ingredient/ingredient.service.ts
@@ -182,6 +182,16 @@ export class IngredientService {
       where: { isRestrictedIngredient: true },
       order: { id: 'ASC' },
     });
+
+    // 카테고리 일괄 조회
+    const categoryIds = [
+      ...new Set(restrictedIngredients.map((i) => i.ingredientCategoryId)),
+    ];
+    const categories = await this.ingredientCategoryRepository.find({
+      where: { id: In(categoryIds) },
+    });
+    const categoryMap = new Map(categories.map((c) => [c.id, c.name]));
+
     const unavailableIngredients =
       await this.userUnavailableIngredientRepository.find({
         where: { userId },
@@ -190,10 +200,13 @@ export class IngredientService {
     const unavailableIngredientIds = new Set(
       unavailableIngredients.map((item) => item.ingredientId),
     );
+
     return {
       data: restrictedIngredients.map((ingredient) => ({
         id: ingredient.id,
         name: ingredient.name,
+        categoryName:
+          categoryMap.get(ingredient.ingredientCategoryId) || '미분류',
         isUserRestricted: unavailableIngredientIds.has(ingredient.id),
       })),
     };


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 못 먹는 음식 목록 조회(온보딩) 수정 (반환값에 카테고리 네임 추가)

### ✨ 변경 내용  
---  
- 못 먹는 음식 목록 조회(온보딩) 수정 (반환값에 카테고리 네임 추가)

### 🛠 테스트 방법  
---   

### 📌 관련 이슈  
---  

### 📎 참고 사항  
---  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신기능**
  * 제한 성분 정보에 카테고리 이름이 추가되었습니다. 카테고리 정보가 없는 경우 '미분류'로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->