### PR TITLE
feat: 공개 레시피 조회 API 추가

### DIFF
--- a/src/api/recipe/dto/get-recipe.dto.ts
+++ b/src/api/recipe/dto/get-recipe.dto.ts
@@ -131,6 +131,13 @@ export class RecipeStepDto {
   summary: string;
 
   @ApiProperty({
+    description: '조리 단계 본문',
+    example: '고등어를 깨끗이 씻어서 3등분으로 자릅니다.',
+    type: 'string',
+  })
+  content: string;
+
+  @ApiProperty({
     description: '요리 예시 이미지 주소',
     example: 'https://example.com/step1.jpg',
     type: 'string',

--- a/src/api/recipe/recipe.controller.ts
+++ b/src/api/recipe/recipe.controller.ts
@@ -28,6 +28,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Response } from 'express';
+import { Public } from '../auth/decorators/auth.decorators';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { JwtGuard } from '../auth/guards/auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -348,6 +349,123 @@ export class RecipeController {
   ): Promise<{ message: string }> {
     await this.recipeService.deleteRecipe(id);
     return { message: '레시피가 삭제되었습니다.' };
+  }
+
+  @Get('/public/:id')
+  @Public()
+  @ApiOperation({
+    summary: '레시피 상세 조회 (공개)',
+    description:
+      '레시피 ID로 상세 정보를 조회합니다. 인증 없이 접근 가능합니다. 사용자의 재료 보유 상태는 인증된 경우에만 포함됩니다.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: '조회할 레시피 ID',
+    type: 'number',
+    example: 1,
+  })
+  @ApiSuccessResponse('레시피 상세 조회 성공', {
+    type: 'object',
+    properties: {
+      id: { type: 'number', example: 1 },
+      title: { type: 'string', example: '간장 고등어 구이' },
+      description: {
+        type: 'string',
+        example: '고소하고 짭짤한 간장 고등어 구이입니다. 밥반찬으로 최고!',
+      },
+      duration: { type: 'number', example: 30 },
+      condition: { type: 'string', example: '힘들어' },
+      images: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'number', example: 1 },
+            image_url: {
+              type: 'string',
+              example: 'https://example.com/recipe.jpg',
+            },
+          },
+        },
+      },
+      ingredients: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'number', example: 1 },
+            name: { type: 'string', example: '고등어' },
+            amount: { type: 'string', example: '1마리' },
+            is_alternative: { type: 'boolean', example: false },
+            ownership_status: {
+              type: 'string',
+              enum: ['owned', 'not_owned', 'alternative_unavailable'],
+              example: 'owned',
+            },
+          },
+        },
+      },
+      seasonings: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'number', example: 1 },
+            name: { type: 'string', example: '간장' },
+            amount: { type: 'string', example: '2큰술' },
+          },
+        },
+      },
+      tools: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'number', example: 1 },
+            name: { type: 'string', example: '프라이팬(원팬)' },
+            image_url: {
+              type: 'string',
+              example: 'https://example.com/pan.jpg',
+            },
+          },
+        },
+      },
+      steps: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            order_num: { type: 'number', example: 1 },
+            summary: { type: 'string', example: '고등어 손질하기' },
+            content: {
+              type: 'string',
+              example: '고등어를 깨끗이 씻어서 3등분으로 자릅니다.',
+            },
+            image_url: {
+              type: 'string',
+              example: 'https://example.com/step1.jpg',
+            },
+          },
+        },
+      },
+      healthPoint: {
+        type: 'object',
+        properties: {
+          content: {
+            type: 'string',
+            example: '고등어의 오메가3가 심혈관 건강에 도움을 줍니다',
+          },
+        },
+      },
+      isBookmarked: { type: 'boolean', example: true },
+    },
+  })
+  @ApiErrorResponse(404, ERROR_CODES.RECIPE_NOT_FOUND)
+  @ApiErrorResponse(404, ERROR_CODES.INGREDIENT_HEALTH_INFO_NOT_FOUND)
+  async getRecipePublic(
+    @Param('id', ParseIntPipe) recipeId: number,
+  ): Promise<GetRecipeResponseDto> {
+    return await this.recipeService.getRecipe(undefined, recipeId);
   }
 
   @Get(':id')

--- a/src/api/recipe/recipe.service.spec.ts
+++ b/src/api/recipe/recipe.service.spec.ts
@@ -50,6 +50,18 @@ const createRepositoryMock = <T>(): MockType<Repository<T>> => ({
 describe('RecipeService', () => {
   let service: RecipeService;
   let recipeRepository: MockType<Repository<Recipe>>;
+  let recipeImageRepository: MockType<Repository<RecipeImage>>;
+  let recipeIngredientRepository: MockType<Repository<RecipeIngredient>>;
+  let recipeSeasoningRepository: MockType<Repository<RecipeSeasoning>>;
+  let recipeToolRepository: MockType<Repository<RecipeTool>>;
+  let recipeStepRepository: MockType<Repository<RecipeStep>>;
+  let ingredientRepository: MockType<Repository<Ingredient>>;
+  let seasoningRepository: MockType<Repository<Seasoning>>;
+  let toolRepository: MockType<Repository<Tool>>;
+  let ingredientHealthInfoRepository: MockType<
+    Repository<IngredientHealthInfo>
+  >;
+  let userRecipeBookmarkRepository: MockType<Repository<UserRecipeBookmark>>;
   let recipeRecommendationService: jest.Mocked<RecipeRecommendationService>;
   let conditionRepository: MockType<Repository<Condition>>;
   let recipeRecommendationConditionRepository: MockType<
@@ -145,6 +157,22 @@ describe('RecipeService', () => {
 
     service = module.get<RecipeService>(RecipeService);
     recipeRepository = module.get(getRepositoryToken(Recipe));
+    recipeImageRepository = module.get(getRepositoryToken(RecipeImage));
+    recipeIngredientRepository = module.get(
+      getRepositoryToken(RecipeIngredient),
+    );
+    recipeSeasoningRepository = module.get(getRepositoryToken(RecipeSeasoning));
+    recipeToolRepository = module.get(getRepositoryToken(RecipeTool));
+    recipeStepRepository = module.get(getRepositoryToken(RecipeStep));
+    ingredientRepository = module.get(getRepositoryToken(Ingredient));
+    seasoningRepository = module.get(getRepositoryToken(Seasoning));
+    toolRepository = module.get(getRepositoryToken(Tool));
+    ingredientHealthInfoRepository = module.get(
+      getRepositoryToken(IngredientHealthInfo),
+    );
+    userRecipeBookmarkRepository = module.get(
+      getRepositoryToken(UserRecipeBookmark),
+    );
     recipeRecommendationService = module.get(RecipeRecommendationService);
     conditionRepository = module.get(getRepositoryToken(Condition));
     recipeRecommendationConditionRepository = module.get(
@@ -268,6 +296,225 @@ describe('RecipeService', () => {
       expect(
         recipeRecommendationService.invalidateCacheByRecipeId,
       ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getRecipe', () => {
+    const recipeId = 1;
+    const userId = 1;
+
+    const mockRecipe: Recipe = {
+      id: recipeId,
+      title: '테스트 레시피',
+      description: '테스트 설명',
+      duration: '30분',
+    } as unknown as Recipe;
+
+    const mockImages: RecipeImage[] = [
+      {
+        id: 1,
+        recipeId,
+        imageUrl: 'https://example.com/image1.jpg',
+      } as RecipeImage,
+    ];
+
+    const mockRecipeIngredients: RecipeIngredient[] = [
+      {
+        id: 1,
+        recipeId,
+        ingredientId: 1,
+        amount: '1마리',
+        isAlternative: false,
+      } as RecipeIngredient,
+      {
+        id: 2,
+        recipeId,
+        ingredientId: 2,
+        amount: '2큰술',
+        isAlternative: true,
+      } as RecipeIngredient,
+    ];
+
+    const mockRecipeSeasonings: RecipeSeasoning[] = [
+      {
+        id: 1,
+        recipeId,
+        seasoningId: 1,
+        amount: '1큰술',
+      } as RecipeSeasoning,
+    ];
+
+    const mockRecipeTools: RecipeTool[] = [
+      {
+        id: 1,
+        recipeId,
+        toolId: 1,
+      } as RecipeTool,
+    ];
+
+    const mockSteps: RecipeStep[] = [
+      {
+        id: 1,
+        recipeId,
+        orderNum: 1,
+        summary: '요약',
+        content: '내용',
+        imageUrl: 'https://example.com/step1.jpg',
+      } as RecipeStep,
+    ];
+
+    const mockIngredients: Ingredient[] = [
+      { id: 1, name: '고등어' } as Ingredient,
+      { id: 2, name: '양파' } as Ingredient,
+    ];
+
+    const mockSeasonings: Seasoning[] = [{ id: 1, name: '간장' } as Seasoning];
+
+    const mockTools: Tool[] = [
+      {
+        id: 1,
+        name: '팬',
+        imageUrl: 'https://example.com/pan.jpg',
+      } as Tool,
+    ];
+
+    const mockHealthInfo: IngredientHealthInfo[] = [
+      {
+        id: 1,
+        ingredientId: 1,
+        content: '고등어는 오메가3가 풍부합니다.',
+      } as IngredientHealthInfo,
+    ];
+
+    beforeEach(() => {
+      recipeRepository.findOne.mockResolvedValue(mockRecipe);
+      recipeImageRepository.find.mockResolvedValue(mockImages);
+      recipeIngredientRepository.find.mockResolvedValue(mockRecipeIngredients);
+      recipeSeasoningRepository.find.mockResolvedValue(mockRecipeSeasonings);
+      recipeToolRepository.find.mockResolvedValue(mockRecipeTools);
+      recipeStepRepository.find.mockResolvedValue(mockSteps);
+      ingredientRepository.find.mockResolvedValue(mockIngredients);
+      seasoningRepository.find.mockResolvedValue(mockSeasonings);
+      toolRepository.find.mockResolvedValue(mockTools);
+      ingredientHealthInfoRepository.find.mockResolvedValue(mockHealthInfo);
+      cacheServiceMock.get.mockResolvedValue(null);
+    });
+
+    it('userId가 undefined일 때 (공개 API) 북마크는 항상 false', async () => {
+      const result = await service.getRecipe(undefined, recipeId);
+
+      expect(result.isBookmarked).toBe(false);
+      expect(userRecipeBookmarkRepository.findOne).not.toHaveBeenCalled();
+      expect(cacheServiceMock.get).not.toHaveBeenCalled();
+    });
+
+    it('userId가 undefined일 때 getUserOwnedIngredients를 호출하지 않음', async () => {
+      const result = await service.getRecipe(undefined, recipeId);
+
+      expect(result.ingredients.owned).toEqual([]);
+      expect(result.ingredients.notOwned.length).toBeGreaterThan(0);
+      expect(cacheServiceMock.get).not.toHaveBeenCalled();
+    });
+
+    it('userId가 있을 때 북마크 조회를 수행함', async () => {
+      const mockBookmark = {
+        id: 1,
+        userId,
+        recipeId,
+      } as UserRecipeBookmark;
+
+      userRecipeBookmarkRepository.findOne.mockResolvedValue(mockBookmark);
+      cacheServiceMock.get.mockResolvedValue(JSON.stringify([1]));
+
+      const result = await service.getRecipe(userId, recipeId);
+
+      expect(userRecipeBookmarkRepository.findOne).toHaveBeenCalledWith({
+        where: { userId, recipeId },
+      });
+      expect(result.isBookmarked).toBe(true);
+    });
+
+    it('userId가 있을 때 북마크가 없으면 false 반환', async () => {
+      userRecipeBookmarkRepository.findOne.mockResolvedValue(null);
+      cacheServiceMock.get.mockResolvedValue(JSON.stringify([1]));
+
+      const result = await service.getRecipe(userId, recipeId);
+
+      expect(result.isBookmarked).toBe(false);
+    });
+
+    it('userId가 있을 때 사용자 보유 재료를 조회함', async () => {
+      const ownedIngredientIds = [1];
+      userRecipeBookmarkRepository.findOne.mockResolvedValue(null);
+      cacheServiceMock.get.mockResolvedValue(
+        JSON.stringify(ownedIngredientIds),
+      );
+
+      const result = await service.getRecipe(userId, recipeId);
+
+      expect(cacheServiceMock.get).toHaveBeenCalledWith(
+        `user:${userId}:owned_ingredients`,
+      );
+      expect(result.ingredients.owned.length).toBeGreaterThan(0);
+    });
+
+    it('레시피가 없으면 RECIPE_NOT_FOUND 에러 발생', async () => {
+      recipeRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getRecipe(undefined, recipeId)).rejects.toThrow(
+        CustomException,
+      );
+    });
+
+    it('정상적으로 레시피 정보를 반환함', async () => {
+      userRecipeBookmarkRepository.findOne.mockResolvedValue(null);
+      cacheServiceMock.get.mockResolvedValue(null);
+
+      const result = await service.getRecipe(undefined, recipeId);
+
+      expect(result.id).toBe(recipeId);
+      expect(result.title).toBe(mockRecipe.title);
+      expect(result.description).toBe(mockRecipe.description);
+      expect(result.duration).toBe(mockRecipe.duration);
+      expect(result.images).toHaveLength(1);
+      expect(result.images[0].id).toBe(mockImages[0].id);
+      expect(result.images[0].imageUrl).toBe(mockImages[0].imageUrl);
+      expect(result.seasonings).toHaveLength(1);
+      expect(result.tools).toHaveLength(1);
+      expect(result.steps).toHaveLength(1);
+      expect(result.healthPoint).toHaveProperty('content');
+      expect(result.isBookmarked).toBe(false);
+    });
+
+    it('재료가 보유/미보유로 올바르게 분류됨', async () => {
+      const ownedIngredientIds = [1];
+      userRecipeBookmarkRepository.findOne.mockResolvedValue(null);
+      cacheServiceMock.get.mockResolvedValue(
+        JSON.stringify(ownedIngredientIds),
+      );
+
+      const result = await service.getRecipe(userId, recipeId);
+
+      // ingredientId 1은 owned에 있어야 함
+      expect(result.ingredients.owned.some((ing) => ing.id === 1)).toBeTruthy();
+      // ingredientId 2는 notOwned에 있어야 함
+      expect(
+        result.ingredients.notOwned.some((ing) => ing.id === 2),
+      ).toBeTruthy();
+    });
+
+    it('대체 불가능한 재료는 alternativeUnavailable에 포함됨', async () => {
+      userRecipeBookmarkRepository.findOne.mockResolvedValue(null);
+      cacheServiceMock.get.mockResolvedValue(null);
+
+      const result = await service.getRecipe(undefined, recipeId);
+
+      // isAlternative가 false인 재료는 alternativeUnavailable에 포함
+      expect(
+        result.ingredients.alternativeUnavailable.some(
+          (ing) => ing.id === 1 && !ing.isAlternative,
+        ),
+      ).toBeTruthy();
     });
   });
 });

--- a/src/api/recipe/recipe.service.spec.ts
+++ b/src/api/recipe/recipe.service.spec.ts
@@ -482,6 +482,10 @@ describe('RecipeService', () => {
       expect(result.seasonings).toHaveLength(1);
       expect(result.tools).toHaveLength(1);
       expect(result.steps).toHaveLength(1);
+      expect(result.steps[0]).toHaveProperty('orderNum');
+      expect(result.steps[0]).toHaveProperty('summary');
+      expect(result.steps[0]).toHaveProperty('content');
+      expect(result.steps[0]).toHaveProperty('imageUrl');
       expect(result.healthPoint).toHaveProperty('content');
       expect(result.isBookmarked).toBe(false);
     });

--- a/src/api/recipe/recipe.service.ts
+++ b/src/api/recipe/recipe.service.ts
@@ -308,6 +308,7 @@ export class RecipeService {
         .map((step) => ({
           orderNum: step.orderNum,
           summary: step.summary,
+          content: step.content,
           imageUrl: step.imageUrl,
         })),
       healthPoint,

--- a/src/api/recipe/recipe.service.ts
+++ b/src/api/recipe/recipe.service.ts
@@ -208,119 +208,119 @@ export class RecipeService {
   }
 
   async getRecipe(
-    userId: number,
+    userId: number | undefined,
     recipeId: number,
   ): Promise<GetRecipeResponseDto> {
-    try {
-      const recipe = await this.recipeRepository.findOne({
-        where: { id: recipeId },
-      });
-      if (!recipe) {
-        throw new CustomException(ERROR_CODES.RECIPE_NOT_FOUND);
-      }
-
-      const [
-        images,
-        recipeIngredients,
-        recipeSeasonings,
-        recipeTools,
-        steps,
-        userBookmark,
-      ] = await Promise.all([
-        this.recipeImageRepository.find({ where: { recipeId } }),
-        this.recipeIngredientRepository.find({ where: { recipeId } }),
-        this.recipeSeasoningRepository.find({ where: { recipeId } }),
-        this.recipeToolRepository.find({ where: { recipeId } }),
-        this.recipeStepRepository.find({ where: { recipeId } }),
-        this.userRecipeBookmarkRepository.findOne({
-          where: { userId, recipeId },
-        }),
-      ]);
-
-      const ingredientIds = recipeIngredients.map((item) => item.ingredientId);
-      const seasoningIds = recipeSeasonings.map((item) => item.seasoningId);
-      const toolIds = recipeTools.map((item) => item.toolId);
-
-      const [ingredients, seasonings, tools] = await Promise.all([
-        ingredientIds.length
-          ? this.ingredientRepository.find({ where: { id: In(ingredientIds) } })
-          : [],
-        seasoningIds.length
-          ? this.seasoningRepository.find({ where: { id: In(seasoningIds) } })
-          : [],
-        toolIds.length
-          ? this.toolRepository.find({ where: { id: In(toolIds) } })
-          : [],
-      ]);
-
-      const ingredientMap = new Map<number, Ingredient>();
-      ingredients.forEach((ingredient) =>
-        ingredientMap.set(ingredient.id, ingredient),
-      );
-
-      const seasoningMap = new Map<number, Seasoning>();
-      seasonings.forEach((seasoning) =>
-        seasoningMap.set(seasoning.id, seasoning),
-      );
-
-      const toolMap = new Map<number, Tool>();
-      tools.forEach((tool) => toolMap.set(tool.id, tool));
-
-      const recipeIngredientsWithDetail: RecipeIngredientDetail[] =
-        recipeIngredients.map((item) => ({
-          ingredientId: item.ingredientId,
-          name: ingredientMap.get(item.ingredientId)?.name ?? '',
-          amount: item.amount,
-          isAlternative: item.isAlternative,
-        }));
-
-      const userOwnedIngredients = await this.getUserOwnedIngredients(userId);
-      const healthPoint = await this.getRandomHealthPoint(ingredientIds);
-
-      return {
-        id: recipe.id,
-        title: recipe.title,
-        description: recipe.description,
-        duration: recipe.duration,
-        images: images.map((image) => ({
-          id: image.id,
-          imageUrl: image.imageUrl,
-        })),
-        ingredients: this.mapIngredientsWithOwnership(
-          recipeIngredientsWithDetail,
-          userOwnedIngredients,
-        ),
-        seasonings: recipeSeasonings.map((seasoning) => ({
-          id: seasoning.seasoningId,
-          name: seasoningMap.get(seasoning.seasoningId)?.name ?? '',
-          amount: seasoning.amount,
-        })),
-        tools: recipeTools.map((tool) => ({
-          id: tool.toolId,
-          name: toolMap.get(tool.toolId)?.name ?? '',
-          imageUrl: toolMap.get(tool.toolId)?.imageUrl ?? '',
-        })),
-        steps: steps
-          .sort((a, b) => a.orderNum - b.orderNum)
-          .map((step) => ({
-            orderNum: step.orderNum,
-            summary: step.summary,
-            imageUrl: step.imageUrl,
-          })),
-        healthPoint,
-        isBookmarked: !!userBookmark,
-      };
-    } catch (error) {
-      this.logger.error('레시피 조회 중 에러 발생', error);
-      // CustomException인 경우 그대로 전파 (예: INGREDIENT_HEALTH_INFO_NOT_FOUND)
-      if (error instanceof CustomException) {
-        throw error;
-      }
-      throw new CustomException(ERROR_CODES.RECIPE_GET_FAILED);
+    const recipe = await this.recipeRepository.findOne({
+      where: { id: recipeId },
+    });
+    if (!recipe) {
+      throw new CustomException(ERROR_CODES.RECIPE_NOT_FOUND);
     }
+
+    const [
+      images,
+      recipeIngredients,
+      recipeSeasonings,
+      recipeTools,
+      steps,
+      userBookmark,
+    ] = await Promise.all([
+      this.recipeImageRepository.find({ where: { recipeId } }),
+      this.recipeIngredientRepository.find({ where: { recipeId } }),
+      this.recipeSeasoningRepository.find({ where: { recipeId } }),
+      this.recipeToolRepository.find({ where: { recipeId } }),
+      this.recipeStepRepository.find({ where: { recipeId } }),
+      userId
+        ? this.userRecipeBookmarkRepository.findOne({
+            where: { userId, recipeId },
+          })
+        : Promise.resolve(null),
+    ]);
+
+    const ingredientIds = recipeIngredients.map((item) => item.ingredientId);
+    const seasoningIds = recipeSeasonings.map((item) => item.seasoningId);
+    const toolIds = recipeTools.map((item) => item.toolId);
+
+    const [ingredients, seasonings, tools] = await Promise.all([
+      ingredientIds.length
+        ? this.ingredientRepository.find({ where: { id: In(ingredientIds) } })
+        : [],
+      seasoningIds.length
+        ? this.seasoningRepository.find({ where: { id: In(seasoningIds) } })
+        : [],
+      toolIds.length
+        ? this.toolRepository.find({ where: { id: In(toolIds) } })
+        : [],
+    ]);
+
+    const ingredientMap = new Map<number, Ingredient>();
+    ingredients.forEach((ingredient) =>
+      ingredientMap.set(ingredient.id, ingredient),
+    );
+
+    const seasoningMap = new Map<number, Seasoning>();
+    seasonings.forEach((seasoning) =>
+      seasoningMap.set(seasoning.id, seasoning),
+    );
+
+    const toolMap = new Map<number, Tool>();
+    tools.forEach((tool) => toolMap.set(tool.id, tool));
+
+    const recipeIngredientsWithDetail: RecipeIngredientDetail[] =
+      recipeIngredients.map((item) => ({
+        ingredientId: item.ingredientId,
+        name: ingredientMap.get(item.ingredientId)?.name ?? '',
+        amount: item.amount,
+        isAlternative: item.isAlternative,
+      }));
+
+    const userOwnedIngredients = userId
+      ? await this.getUserOwnedIngredients(userId)
+      : [];
+    const healthPoint = await this.getRandomHealthPoint(ingredientIds);
+
+    return {
+      id: recipe.id,
+      title: recipe.title,
+      description: recipe.description,
+      duration: recipe.duration,
+      images: images.map((image) => ({
+        id: image.id,
+        imageUrl: image.imageUrl,
+      })),
+      ingredients: this.mapIngredientsWithOwnership(
+        recipeIngredientsWithDetail,
+        userOwnedIngredients,
+      ),
+      seasonings: recipeSeasonings.map((seasoning) => ({
+        id: seasoning.seasoningId,
+        name: seasoningMap.get(seasoning.seasoningId)?.name ?? '',
+        amount: seasoning.amount,
+      })),
+      tools: recipeTools.map((tool) => ({
+        id: tool.toolId,
+        name: toolMap.get(tool.toolId)?.name ?? '',
+        imageUrl: toolMap.get(tool.toolId)?.imageUrl ?? '',
+      })),
+      steps: steps
+        .sort((a, b) => a.orderNum - b.orderNum)
+        .map((step) => ({
+          orderNum: step.orderNum,
+          summary: step.summary,
+          imageUrl: step.imageUrl,
+        })),
+      healthPoint,
+      isBookmarked: userId ? !!userBookmark : false,
+    };
   }
 
-  private async getUserOwnedIngredients(userId: number): Promise<number[]> {
+  private async getUserOwnedIngredients(
+    userId: number | undefined,
+  ): Promise<number[]> {
+    if (!userId) {
+      return [];
+    }
     try {
       const cacheKey = `user:${userId}:owned_ingredients`;
       const cachedIngredients = await this.cacheService.get(cacheKey);


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 인증 없이 접근 가능한 공개 레시피 조회 엔드포인트 추가

### ✨ 변경 내용  
---  
- [ ] (변경된 사항 요약) 
- [x] (새로 추가된 기능이나 수정된 내용)  
- [ ] (리팩토링 및 코드 개선 사항)  

### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 로그인하지 않아도 레시피 상세를 조회할 수 있는 공개 엔드포인트 추가
  * 레시피 단계에 전체 내용(content) 표시 항목 추가

* **Behavior Changes**
  * 비인증 상태에서는 북마크가 항상 없음으로 처리되고, 소유 재료는 빈 목록으로 표시

* **Tests**
  * 레시피 조회 관련 포괄적 테스트 추가(북마크, 소유 재료, 전체 반환 구조 등)

* **Bug Fixes**
  * 동일한 공개 엔드포인트 중복 등록으로 인한 경로 충돌 가능성 발견 및 주의 필요
<!-- end of auto-generated comment: release notes by coderabbit.ai -->