### PR TITLE
feat: 건강 설문 effectCodes 조건부 필수 검증 추가

### DIFF
--- a/src/api/health-survey/constants/health-survey.constants.ts
+++ b/src/api/health-survey/constants/health-survey.constants.ts
@@ -1,0 +1,10 @@
+/**
+ * 건강 설문 관련 상수
+ */
+export const HEALTH_SURVEY_CONSTANTS = {
+  /**
+   * effectCodes가 필수인 persistentIssueCode 목록
+   * 이 코드들을 선택한 경우 effectCodes는 반드시 제공되어야 합니다.
+   */
+  REQUIRES_EFFECT_CODES: ['H01003'] as const,
+} as const;

--- a/src/api/health-survey/dto/create-health-survey.dto.ts
+++ b/src/api/health-survey/dto/create-health-survey.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  ArrayNotEmpty,
   ArrayUnique,
   IsArray,
   IsNotEmpty,
@@ -24,7 +23,6 @@ export class CreateHealthSurveyRequestDto {
     type: [String],
   })
   @IsArray()
-  @ArrayNotEmpty()
   @ArrayUnique()
   @IsString({ each: true })
   effectCodes: string[];

--- a/src/api/health-survey/health-survey.service.spec.ts
+++ b/src/api/health-survey/health-survey.service.spec.ts
@@ -1,0 +1,498 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { ERROR_CODES } from '@/common/constants/error-codes';
+import { CustomException } from '@/common/exceptions/custom-exception';
+import { CommonCode } from '@/database/entity/common-code.entity';
+import { UserCompletedRecipe } from '@/database/entity/user-completed-recipe.entity';
+import { UserHealthSurveyEffect } from '@/database/entity/user-health-survey-effect.entity';
+import { UserHealthSurvey } from '@/database/entity/user-health-survey.entity';
+import { HEALTH_SURVEY_CONSTANTS } from './constants/health-survey.constants';
+import { HealthSurveyService } from './health-survey.service';
+
+describe('HealthSurveyService', () => {
+  let service: HealthSurveyService;
+  let userCompletedRecipeRepository: jest.Mocked<
+    Repository<UserCompletedRecipe>
+  >;
+  let userHealthSurveyRepository: jest.Mocked<Repository<UserHealthSurvey>>;
+  let userHealthSurveyEffectRepository: jest.Mocked<
+    Repository<UserHealthSurveyEffect>
+  >;
+  let commonCodeRepository: jest.Mocked<Repository<CommonCode>>;
+
+  const mockUserCompletedRecipeRepository = {
+    count: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockUserHealthSurveyRepository = {
+    exist: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockUserHealthSurveyEffectRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockCommonCodeRepository = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HealthSurveyService,
+        {
+          provide: getRepositoryToken(UserCompletedRecipe),
+          useValue: mockUserCompletedRecipeRepository,
+        },
+        {
+          provide: getRepositoryToken(UserHealthSurvey),
+          useValue: mockUserHealthSurveyRepository,
+        },
+        {
+          provide: getRepositoryToken(UserHealthSurveyEffect),
+          useValue: mockUserHealthSurveyEffectRepository,
+        },
+        {
+          provide: getRepositoryToken(CommonCode),
+          useValue: mockCommonCodeRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<HealthSurveyService>(HealthSurveyService);
+    userCompletedRecipeRepository = module.get(
+      getRepositoryToken(UserCompletedRecipe),
+    );
+    userHealthSurveyRepository = module.get(
+      getRepositoryToken(UserHealthSurvey),
+    );
+    userHealthSurveyEffectRepository = module.get(
+      getRepositoryToken(UserHealthSurveyEffect),
+    );
+    commonCodeRepository = module.get(getRepositoryToken(CommonCode));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getEligibility', () => {
+    const userId = 1;
+
+    it('레시피 완료 이력이 있고 이번 주 설문 제출 이력이 없으면 작성 가능해야 한다', async () => {
+      userCompletedRecipeRepository.count.mockResolvedValue(2);
+      userHealthSurveyRepository.exist.mockResolvedValue(false);
+
+      const result = await service.getEligibility(userId);
+
+      expect(result.isEligible).toBe(true);
+      expect(result.recentCompletionCount).toBe(2);
+    });
+
+    it('레시피 완료 이력이 없으면 작성 불가능해야 한다', async () => {
+      userCompletedRecipeRepository.count.mockResolvedValue(0);
+      userHealthSurveyRepository.exist.mockResolvedValue(false);
+
+      const result = await service.getEligibility(userId);
+
+      expect(result.isEligible).toBe(false);
+      expect(result.recentCompletionCount).toBe(0);
+    });
+
+    it('이번 주 설문 제출 이력이 있으면 작성 불가능해야 한다', async () => {
+      userCompletedRecipeRepository.count.mockResolvedValue(2);
+      userHealthSurveyRepository.exist.mockResolvedValue(true);
+
+      const result = await service.getEligibility(userId);
+
+      expect(result.isEligible).toBe(false);
+      expect(result.recentCompletionCount).toBe(2);
+    });
+  });
+
+  describe('getPreparationData', () => {
+    it('건강 설문 준비 데이터를 반환해야 한다', async () => {
+      const mockPersistentIssueCodes: CommonCode[] = [
+        {
+          id: 1,
+          groupCode: 'H01',
+          code: 'H01002',
+          codeName: '전과 비슷해요.',
+          groupCodeName: 'HEALTH_PERSISTENT_ISSUE',
+          groupName: '평소 겪던 건강 문제',
+          orderNum: 2,
+          isActive: true,
+          depth: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as CommonCode,
+        {
+          id: 2,
+          groupCode: 'H01',
+          code: 'H01003',
+          codeName: '개선됨을 느껴요.',
+          groupCodeName: 'HEALTH_PERSISTENT_ISSUE',
+          groupName: '평소 겪던 건강 문제',
+          orderNum: 3,
+          isActive: true,
+          depth: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as CommonCode,
+      ];
+
+      const mockEffectCodes: CommonCode[] = [
+        {
+          id: 3,
+          groupCode: 'H02',
+          code: 'H02001',
+          codeName: '피로가 줄었다.',
+          groupCodeName: 'HEALTH_PERCEIVED_EFFECT',
+          groupName: '느낀 변화',
+          orderNum: 1,
+          isActive: true,
+          depth: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as CommonCode,
+        {
+          id: 4,
+          groupCode: 'H02',
+          code: 'H02004',
+          codeName: '체중 관리에 도움이 된다.',
+          groupCodeName: 'HEALTH_PERCEIVED_EFFECT',
+          groupName: '느낀 변화',
+          orderNum: 4,
+          isActive: true,
+          depth: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as CommonCode,
+      ];
+
+      commonCodeRepository.find
+        .mockResolvedValueOnce(mockPersistentIssueCodes)
+        .mockResolvedValueOnce(mockEffectCodes);
+
+      const result = await service.getPreparationData();
+
+      expect(result.persistentIssueOption).toHaveLength(2);
+      expect(result.persistentIssueOption[0]).toEqual({
+        code: 'H01002',
+        codeName: '전과 비슷해요.',
+      });
+      expect(result.effectOptions).toHaveLength(2);
+      expect(result.effectOptions[0]).toEqual({
+        code: 'H02001',
+        codeName: '피로가 줄었다.',
+      });
+    });
+  });
+
+  describe('submitHealthSurvey', () => {
+    const userId = 1;
+
+    beforeEach(() => {
+      // getEligibility를 위한 기본 mock 설정
+      userCompletedRecipeRepository.count.mockResolvedValue(2);
+      userHealthSurveyRepository.exist.mockResolvedValue(false);
+    });
+
+    it('일반 코드와 effectCodes가 있을 때 에러를 발생시켜야 한다', async () => {
+      const dto = {
+        persistentIssueCode: 'H01002',
+        effectCodes: ['H02001', 'H02004'],
+        additionalNote: '테스트 노트',
+      };
+
+      const mockPersistentIssueCode: CommonCode = {
+        id: 1,
+        groupCode: 'H01',
+        code: 'H01002',
+        codeName: '전과 비슷해요.',
+        isActive: true,
+      } as CommonCode;
+
+      commonCodeRepository.findOne.mockResolvedValue(mockPersistentIssueCode);
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        CustomException,
+      );
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        ERROR_CODES.HEALTH_SURVEY_EFFECT_CODES_NOT_ALLOWED.message,
+      );
+
+      expect(userHealthSurveyRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('일반 코드와 effectCodes가 빈 배열일 때 성공해야 한다', async () => {
+      const dto = {
+        persistentIssueCode: 'H01002',
+        effectCodes: [],
+        additionalNote: null,
+      };
+
+      const mockPersistentIssueCode: CommonCode = {
+        id: 1,
+        groupCode: 'H01',
+        code: 'H01002',
+        codeName: '전과 비슷해요.',
+        isActive: true,
+      } as CommonCode;
+
+      const mockSavedSurvey: UserHealthSurvey = {
+        id: 1,
+        userId,
+        persistentIssueCode: dto.persistentIssueCode,
+        additionalNote: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as UserHealthSurvey;
+
+      commonCodeRepository.findOne.mockResolvedValue(mockPersistentIssueCode);
+      commonCodeRepository.find.mockResolvedValue([]);
+      userHealthSurveyRepository.create.mockReturnValue({
+        userId,
+        persistentIssueCode: dto.persistentIssueCode,
+        additionalNote: null,
+      } as UserHealthSurvey);
+      userHealthSurveyRepository.save.mockResolvedValue(mockSavedSurvey);
+
+      const result = await service.submitHealthSurvey(userId, dto);
+
+      expect(result.surveyId).toBe(1);
+      expect(userHealthSurveyRepository.save).toHaveBeenCalled();
+      expect(userHealthSurveyEffectRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('H01003 코드와 effectCodes가 있을 때 성공해야 한다', async () => {
+      const dto = {
+        persistentIssueCode: 'H01003',
+        effectCodes: ['H02001'],
+        additionalNote: null,
+      };
+
+      const mockPersistentIssueCode: CommonCode = {
+        id: 1,
+        groupCode: 'H01',
+        code: 'H01003',
+        codeName: '개선됨을 느껴요.',
+        isActive: true,
+      } as CommonCode;
+
+      const mockEffectCodes: CommonCode[] = [
+        {
+          id: 2,
+          groupCode: 'H02',
+          code: 'H02001',
+          codeName: '피로가 줄었다.',
+          isActive: true,
+        } as CommonCode,
+      ];
+
+      const mockSavedSurvey: UserHealthSurvey = {
+        id: 1,
+        userId,
+        persistentIssueCode: dto.persistentIssueCode,
+        additionalNote: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as UserHealthSurvey;
+
+      commonCodeRepository.findOne.mockResolvedValue(mockPersistentIssueCode);
+      commonCodeRepository.find.mockResolvedValue(mockEffectCodes);
+      userHealthSurveyRepository.create.mockReturnValue({
+        userId,
+        persistentIssueCode: dto.persistentIssueCode,
+        additionalNote: null,
+      } as UserHealthSurvey);
+      userHealthSurveyRepository.save.mockResolvedValue(mockSavedSurvey);
+      userHealthSurveyEffectRepository.create.mockReturnValue({
+        userHealthSurveyId: 1,
+        effectCode: 'H02001',
+      } as UserHealthSurveyEffect);
+      userHealthSurveyEffectRepository.save.mockResolvedValue([
+        {
+          id: 1,
+          userHealthSurveyId: 1,
+          effectCode: 'H02001',
+        } as UserHealthSurveyEffect,
+      ] as any);
+
+      const result = await service.submitHealthSurvey(userId, dto);
+
+      expect(result.surveyId).toBe(1);
+      expect(userHealthSurveyRepository.save).toHaveBeenCalled();
+      expect(userHealthSurveyEffectRepository.save).toHaveBeenCalled();
+    });
+
+    it('H01003 코드와 effectCodes가 빈 배열일 때 에러를 발생시켜야 한다', async () => {
+      const dto = {
+        persistentIssueCode: 'H01003',
+        effectCodes: [],
+        additionalNote: null,
+      };
+
+      const mockPersistentIssueCode: CommonCode = {
+        id: 1,
+        groupCode: 'H01',
+        code: 'H01003',
+        codeName: '개선됨을 느껴요.',
+        isActive: true,
+      } as CommonCode;
+
+      commonCodeRepository.findOne.mockResolvedValue(mockPersistentIssueCode);
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        CustomException,
+      );
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        ERROR_CODES.HEALTH_SURVEY_EFFECT_CODES_REQUIRED.message,
+      );
+
+      expect(userHealthSurveyRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('작성 자격이 없으면 에러를 발생시켜야 한다', async () => {
+      const dto = {
+        persistentIssueCode: 'H01002',
+        effectCodes: [],
+        additionalNote: null,
+      };
+
+      userCompletedRecipeRepository.count.mockResolvedValue(0);
+      userHealthSurveyRepository.exist.mockResolvedValue(false);
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        CustomException,
+      );
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        ERROR_CODES.HEALTH_SURVEY_NOT_ELIGIBLE.message,
+      );
+    });
+
+    it('잘못된 persistentIssueCode일 때 에러를 발생시켜야 한다', async () => {
+      const dto = {
+        persistentIssueCode: 'INVALID_CODE',
+        effectCodes: [],
+        additionalNote: null,
+      };
+
+      commonCodeRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        CustomException,
+      );
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        ERROR_CODES.COMMON_CODE_NOT_FOUND.message,
+      );
+    });
+
+    it('잘못된 effectCodes일 때 에러를 발생시켜야 한다', async () => {
+      const dto = {
+        persistentIssueCode: 'H01003',
+        effectCodes: ['H02001', 'INVALID_EFFECT'],
+        additionalNote: null,
+      };
+
+      const mockPersistentIssueCode: CommonCode = {
+        id: 1,
+        groupCode: 'H01',
+        code: 'H01003',
+        codeName: '개선됨을 느껴요.',
+        isActive: true,
+      } as CommonCode;
+
+      const mockEffectCodes: CommonCode[] = [
+        {
+          id: 2,
+          groupCode: 'H02',
+          code: 'H02001',
+          codeName: '피로가 줄었다.',
+          isActive: true,
+        } as CommonCode,
+      ];
+
+      commonCodeRepository.findOne.mockResolvedValue(mockPersistentIssueCode);
+      commonCodeRepository.find.mockResolvedValue(mockEffectCodes);
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        CustomException,
+      );
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        ERROR_CODES.COMMON_CODE_NOT_FOUND.message,
+      );
+    });
+
+    it('REQUIRES_EFFECT_CODES에 포함된 다른 코드도 effectCodes가 필수여야 한다', async () => {
+      // 상수에 다른 코드가 추가될 경우를 대비한 테스트
+      const testCode = HEALTH_SURVEY_CONSTANTS.REQUIRES_EFFECT_CODES[0];
+      const dto = {
+        persistentIssueCode: testCode,
+        effectCodes: [],
+        additionalNote: null,
+      };
+
+      const mockPersistentIssueCode: CommonCode = {
+        id: 1,
+        groupCode: 'H01',
+        code: testCode,
+        codeName: '테스트 코드',
+        isActive: true,
+      } as CommonCode;
+
+      commonCodeRepository.findOne.mockResolvedValue(mockPersistentIssueCode);
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        CustomException,
+      );
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        ERROR_CODES.HEALTH_SURVEY_EFFECT_CODES_REQUIRED.message,
+      );
+    });
+
+    it('H01003이 아닌 코드에 effectCodes가 있으면 에러를 발생시켜야 한다', async () => {
+      const dto = {
+        persistentIssueCode: 'H01002',
+        effectCodes: ['H02001'],
+        additionalNote: null,
+      };
+
+      const mockPersistentIssueCode: CommonCode = {
+        id: 1,
+        groupCode: 'H01',
+        code: 'H01002',
+        codeName: '전과 비슷해요.',
+        isActive: true,
+      } as CommonCode;
+
+      commonCodeRepository.findOne.mockResolvedValue(mockPersistentIssueCode);
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        CustomException,
+      );
+
+      await expect(service.submitHealthSurvey(userId, dto)).rejects.toThrow(
+        ERROR_CODES.HEALTH_SURVEY_EFFECT_CODES_NOT_ALLOWED.message,
+      );
+
+      expect(userHealthSurveyRepository.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/api/health-survey/health-survey.service.ts
+++ b/src/api/health-survey/health-survey.service.ts
@@ -2,21 +2,22 @@ import { HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Between, In, Repository } from 'typeorm';
 
-import { UserCompletedRecipe } from '@/database/entity/user-completed-recipe.entity';
-import { HealthSurveyEligibilityResponseDto } from './dto/check-health-survey-eligibility.dto';
+import { ERROR_CODES } from '@/common/constants/error-codes';
+import { CustomException } from '@/common/exceptions/custom-exception';
 import { CommonCode } from '@/database/entity/common-code.entity';
-import {
-  GetHealthSurveyPreparationResponseDto,
-  HealthSurveyCodeOptionDto,
-} from './dto/get-health-survey-preparation.dto';
+import { UserCompletedRecipe } from '@/database/entity/user-completed-recipe.entity';
+import { UserHealthSurveyEffect } from '@/database/entity/user-health-survey-effect.entity';
 import { UserHealthSurvey } from '@/database/entity/user-health-survey.entity';
+import { HEALTH_SURVEY_CONSTANTS } from './constants/health-survey.constants';
+import { HealthSurveyEligibilityResponseDto } from './dto/check-health-survey-eligibility.dto';
 import {
   CreateHealthSurveyRequestDto,
   CreateHealthSurveyResponseDto,
 } from './dto/create-health-survey.dto';
-import { CustomException } from '@/common/exceptions/custom-exception';
-import { ERROR_CODES } from '@/common/constants/error-codes';
-import { UserHealthSurveyEffect } from '@/database/entity/user-health-survey-effect.entity';
+import {
+  GetHealthSurveyPreparationResponseDto,
+  HealthSurveyCodeOptionDto,
+} from './dto/get-health-survey-preparation.dto';
 
 const PERSISTENT_ISSUE_GROUP = 'H01';
 const EFFECT_GROUP = 'H02';
@@ -101,6 +102,27 @@ export class HealthSurveyService {
     });
     if (!persistentIssueCode) {
       throw new CustomException(ERROR_CODES.COMMON_CODE_NOT_FOUND);
+    }
+
+    // effectCodes 검증
+    const requiresEffectCodes = (
+      HEALTH_SURVEY_CONSTANTS.REQUIRES_EFFECT_CODES as readonly string[]
+    ).includes(dto.persistentIssueCode);
+
+    if (requiresEffectCodes && dto.effectCodes.length === 0) {
+      // H01003 등 effectCodes가 필수인 경우
+      throw new CustomException(
+        ERROR_CODES.HEALTH_SURVEY_EFFECT_CODES_REQUIRED,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (!requiresEffectCodes && dto.effectCodes.length > 0) {
+      // H01003이 아닌 경우 effectCodes는 빈 배열이어야 함
+      throw new CustomException(
+        ERROR_CODES.HEALTH_SURVEY_EFFECT_CODES_NOT_ALLOWED,
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     const effectCodes = await this.commonCodeRepository.find({

--- a/src/common/constants/error-codes.ts
+++ b/src/common/constants/error-codes.ts
@@ -95,6 +95,8 @@ export const ERROR_CODES = {
 
   // 건강 설문 오류
   HEALTH_SURVEY_NOT_ELIGIBLE: { code: 'E16001', message: '현재는 건강 설문을 작성할 수 없습니다.' },
+  HEALTH_SURVEY_EFFECT_CODES_REQUIRED: { code: 'E16002', message: '느낀 변화 코드는 필수입니다.' },
+  HEALTH_SURVEY_EFFECT_CODES_NOT_ALLOWED: { code: 'E16003', message: '느낀 변화 코드는 선택할 수 없습니다.' },
 
   // 건강정보 오류
   INGREDIENT_HEALTH_INFO_NOT_FOUND: { code: 'E18001', message: '재료의 건강정보를 찾을 수 없습니다.' },


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 특정 persistentIssueCode 선택 시에만 effectCodes 필수
- effectCodes 빈 배열 허용 (일반적인 경우)

### ✨ 변경 내용  
---  
- [ ] (변경된 사항 요약) 
- [ ] (새로 추가된 기능이나 수정된 내용)  
- [ ] (리팩토링 및 코드 개선 사항)  

### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 건강 설문 제출 시 효과 코드 검증 규칙 추가: 특정 건강 이슈 코드 선택 시 효과 코드 입력을 강제하고, 불필요한 효과 코드 입력을 방지하는 검증 로직 구현

* **테스트**
  * 건강 설문 서비스의 광범위한 단위 테스트 추가: 설문 제출, 데이터 조회, eligibility 확인 등 주요 시나리오 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->