### PR TITLE
chore: 로컬 개발용 docker compose 설정 및 스크립트 정리

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -16,10 +16,10 @@ services:
       - ./docker/mariadb/data:/var/lib/mysql
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
-      interval: 30s
+      interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 3
+      start_period: 10s
     networks:
       - docker-network
     restart: always
@@ -28,7 +28,7 @@ services:
     image: mariadb:10.8.2
     depends_on:
       recipot-mariadb:
-        condition: service_healthy
+        condition: service_started
     env_file:
       - .env.local
     environment:


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- docker-compose.local.yml의 healthcheck 설정을 로컬 개발에 맞게 단축
  - interval 30s → 10s
  - retries 5 → 3
  - start_period 30s → 10s
  - 초기 기동 시 대기 시간이 과도하게 길어지는 문제를 완화

- recipot-mariadb-init 컨테이너 depends_on 조건을 service_healthy → service_started로 변경
  - 로컬 환경에서 healthcheck 완료를 기다리느라 up 시간이 길어지는 현상을 줄임
  - DB가 기동되면 바로 초기화 스크립트가 실행될 수 있도록 조정

### ✨ 변경 내용  
---  
- [ ] (변경된 사항 요약) 
- [ ] (새로 추가된 기능이나 수정된 내용)  
- [ ] (리팩토링 및 코드 개선 사항)  

### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 헬스체크 간격 및 타임아웃을 단축하여 서비스의 응답성을 개선했습니다.
  * 초기 시작 감지 방식을 최적화하여 빠른 시작 시간을 구현했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->