### PR TITLE
feat: 어드민용 레시피 목록 조회 API 추가

### DIFF
--- a/src/api/recipe/dto/get-recipe-list.dto.ts
+++ b/src/api/recipe/dto/get-recipe-list.dto.ts
@@ -1,0 +1,186 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RecipeListToolDto {
+  @ApiProperty({
+    description: '조리도구 ID',
+    example: 1,
+    type: 'number',
+  })
+  id: number;
+
+  @ApiProperty({
+    description: '조리도구 이름',
+    example: '도마',
+    type: 'string',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: '조리도구 이미지 주소',
+    example: 'https://example.com/pan.jpg',
+    nullable: true,
+    type: 'string',
+  })
+  imageUrl: string | null;
+}
+
+export class RecipeListIngredientDto {
+  @ApiProperty({
+    description: '재료 ID',
+    example: 1,
+    type: 'number',
+  })
+  id: number;
+
+  @ApiProperty({
+    description: '재료 이름',
+    example: '부채살',
+    type: 'string',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: '필요량',
+    example: '80g',
+    type: 'string',
+  })
+  amount: string;
+
+  @ApiProperty({
+    description: '대체 가능 여부',
+    example: false,
+    type: 'boolean',
+  })
+  isAlternative: boolean;
+}
+
+export class RecipeListSeasoningDto {
+  @ApiProperty({
+    description: '양념 ID',
+    example: 1,
+    type: 'number',
+  })
+  id: number;
+
+  @ApiProperty({
+    description: '양념 이름',
+    example: '플레인요거트',
+    type: 'string',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: '필요량',
+    example: '2큰술',
+    type: 'string',
+  })
+  amount: string;
+}
+
+export class RecipeListStepDto {
+  @ApiProperty({
+    description: '단계 순서',
+    example: 1,
+    type: 'number',
+  })
+  orderNum: number;
+
+  @ApiProperty({
+    description: '단계 요약',
+    example: '컬리플라워를 잘게 다져주세요.',
+    nullable: true,
+  })
+  summary: string | null;
+
+  @ApiProperty({
+    description: '조리 단계 본문',
+    example: '땅콩버터 한 숟갈을 떠서 식빵에 바른다.',
+    nullable: true,
+  })
+  content: string | null;
+
+  @ApiProperty({
+    description: '요리 예시 이미지 주소',
+    example: 'https://example.com/step1.jpg',
+    nullable: true,
+  })
+  imageUrl: string | null;
+}
+
+export class RecipeListItemDto {
+  @ApiProperty({
+    description: '레시피 ID',
+    example: 1,
+    type: 'number',
+  })
+  id: number;
+
+  @ApiProperty({
+    description: '레시피 타이틀',
+    example: '컬리플라워 부채살 샐러드랩',
+    type: 'string',
+  })
+  title: string;
+
+  @ApiProperty({
+    description: '레시피 이미지 (첫 번째 이미지 URL)',
+    example: 'https://example.com/recipe.jpg',
+    nullable: true,
+    type: 'string',
+  })
+  imageUrl: string | null;
+
+  @ApiProperty({
+    description: '조리 시간 (분)',
+    example: 15,
+    type: 'number',
+  })
+  duration: number;
+
+  @ApiProperty({
+    description: '유저 컨디션',
+    example: '그럭저럭',
+    nullable: true,
+    type: 'string',
+  })
+  condition: string | null;
+
+  @ApiProperty({
+    description: '한줄 카피',
+    example: '빵 위에 땅콩버터와 바나나만 얹으면 끝!',
+    type: 'string',
+  })
+  description: string;
+
+  @ApiProperty({
+    description: '조리도구 목록',
+    type: [RecipeListToolDto],
+  })
+  tools: RecipeListToolDto[];
+
+  @ApiProperty({
+    description: '재료 목록',
+    type: [RecipeListIngredientDto],
+  })
+  ingredients: RecipeListIngredientDto[];
+
+  @ApiProperty({
+    description: '양념 목록',
+    type: [RecipeListSeasoningDto],
+  })
+  seasonings: RecipeListSeasoningDto[];
+
+  @ApiProperty({
+    description: '조리 단계 목록 (순서대로 정렬됨)',
+    type: [RecipeListStepDto],
+  })
+  steps: RecipeListStepDto[];
+}
+
+export class GetRecipeListResponseDto {
+  @ApiProperty({
+    description: '레시피 목록',
+    type: [RecipeListItemDto],
+  })
+  items: RecipeListItemDto[];
+}

--- a/src/api/recipe/dto/get-recipe-list.dto.ts
+++ b/src/api/recipe/dto/get-recipe-list.dto.ts
@@ -15,13 +15,13 @@ export class RecipeListToolDto {
   })
   name: string;
 
-  @ApiProperty({
-    description: '조리도구 이미지 주소',
-    example: 'https://example.com/pan.jpg',
-    nullable: true,
-    type: 'string',
-  })
-  imageUrl: string | null;
+  // TODO: 조리도구 이미지 nullable로 가져갈 것인지 확인 후 추가, 당장 어드민에는 불필요
+  // @ApiProperty({
+  //   description: '조리도구 이미지 주소',
+  //   example: 'https://example.com/pan.jpg',
+  //   type: 'string',
+  // })
+  // imageUrl: string;
 }
 
 export class RecipeListIngredientDto {

--- a/src/api/recipe/recipe.controller.ts
+++ b/src/api/recipe/recipe.controller.ts
@@ -37,6 +37,7 @@ import { CreateRecipeRecommendationConditionRequest } from './dto/create-recipe-
 import { CreateRecipeRecommendationConditionDto } from './dto/create-recipe-recommend.dto';
 import { CreateRecipeDto, UpdateRecipeDto } from './dto/create-recipe.dto';
 import { GetRecipeIngredientsResponseDto } from './dto/get-recipe-ingredients.dto';
+import { GetRecipeListResponseDto } from './dto/get-recipe-list.dto';
 import { GetRecipeRecommendationRequestDto } from './dto/get-recipe-recommendation-request.dto';
 import { GetRecipeRecommendationResponseDto } from './dto/get-recipe-recommendation-response.dto';
 import { GetRecipeRecommendationConditionsResponseDto } from './dto/get-recipe-recommends.dto';
@@ -658,6 +659,25 @@ export class RecipeController {
   ): Promise<GetRecipeResponseDto> {
     const userId = req.user.sub;
     return await this.recipeService.getRecipe(userId, recipeId);
+  }
+
+  // 어드민용 레시피 목록 조회
+  @Get('')
+  @UseGuards(JwtGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('Authorization')
+  @ApiOperation({
+    summary: '[어드민] 레시피 목록 조회',
+    description:
+      '어드민용 레시피 목록을 조회합니다. 레시피 타이틀, 이미지, 조리시간, 컨디션, 한줄 카피, 조리도구, 재료, 양념, 단계별 정보를 포함합니다. 모든 레시피를 반환합니다.',
+  })
+  @ApiSuccessResponse('레시피 목록 조회 성공', {
+    type: GetRecipeListResponseDto,
+  })
+  @ApiErrorResponse(401, ERROR_CODES.AUTH_REQUIRED)
+  @ApiErrorResponse(403, ERROR_CODES.AUTH_PERMISSION_DENIED)
+  async getRecipeList(): Promise<GetRecipeListResponseDto> {
+    return await this.recipeService.getRecipeList();
   }
 
   // 레시피 추천 관련 엔드포인트들

--- a/src/api/recipe/recipe.service.spec.ts
+++ b/src/api/recipe/recipe.service.spec.ts
@@ -16,7 +16,7 @@ import { Tool } from '@/database/entity/tool.entity';
 import { UserRecipeBookmark } from '@/database/entity/user-recipe-bookmark.entity';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { CommonCodeService } from '../common-code/common-code.service';
 import { FileCleanupService } from '../file-cleanup/file-cleanup.service';
 import { CreateRecipeDto } from './dto/create-recipe.dto';
@@ -519,6 +519,291 @@ describe('RecipeService', () => {
           (ing) => ing.id === 1 && !ing.isAlternative,
         ),
       ).toBeTruthy();
+    });
+  });
+
+  describe('getRecipeList', () => {
+    const mockRecipes: Recipe[] = [
+      {
+        id: 1,
+        title: '레시피 1',
+        description: '설명 1',
+        duration: 15,
+        deletedAt: null,
+      } as Recipe,
+      {
+        id: 2,
+        title: '레시피 2',
+        description: '설명 2',
+        duration: 20,
+        deletedAt: null,
+      } as Recipe,
+    ];
+
+    const mockImages: RecipeImage[] = [
+      {
+        id: 1,
+        recipeId: 1,
+        imageUrl: 'https://example.com/image1.jpg',
+      } as RecipeImage,
+      {
+        id: 2,
+        recipeId: 2,
+        imageUrl: 'https://example.com/image2.jpg',
+      } as RecipeImage,
+    ];
+
+    const mockRecipeIngredients: RecipeIngredient[] = [
+      {
+        id: 1,
+        recipeId: 1,
+        ingredientId: 1,
+        amount: '100g',
+        isAlternative: false,
+      } as RecipeIngredient,
+      {
+        id: 2,
+        recipeId: 1,
+        ingredientId: 2,
+        amount: '2개',
+        isAlternative: true,
+      } as RecipeIngredient,
+    ];
+
+    const mockRecipeSeasonings: RecipeSeasoning[] = [
+      {
+        id: 1,
+        recipeId: 1,
+        seasoningId: 1,
+        amount: '1큰술',
+      } as RecipeSeasoning,
+    ];
+
+    const mockRecipeTools: RecipeTool[] = [
+      {
+        id: 1,
+        recipeId: 1,
+        toolId: 1,
+      } as RecipeTool,
+    ];
+
+    const mockSteps: RecipeStep[] = [
+      {
+        id: 1,
+        recipeId: 1,
+        orderNum: 1,
+        summary: '요약 1',
+        content: '내용 1',
+        imageUrl: 'https://example.com/step1.jpg',
+      } as RecipeStep,
+      {
+        id: 2,
+        recipeId: 1,
+        orderNum: 2,
+        summary: '요약 2',
+        content: '내용 2',
+        imageUrl: null,
+      } as RecipeStep,
+    ];
+
+    const mockRecipeRecommendationConditions: RecipeRecommendationCondition[] =
+      [
+        {
+          id: 1,
+          recipeId: 1,
+          conditionId: 1,
+          priorityScore: 1.0,
+        } as RecipeRecommendationCondition,
+      ];
+
+    const mockIngredients: Ingredient[] = [
+      {
+        id: 1,
+        name: '재료1',
+      } as Ingredient,
+      {
+        id: 2,
+        name: '재료2',
+      } as Ingredient,
+    ];
+
+    const mockSeasonings: Seasoning[] = [
+      {
+        id: 1,
+        name: '양념1',
+      } as Seasoning,
+    ];
+
+    const mockTools: Tool[] = [
+      {
+        id: 1,
+        name: '도구1',
+        imageUrl: 'https://example.com/tool1.jpg',
+      } as Tool,
+    ];
+
+    const mockConditions: Condition[] = [
+      {
+        id: 1,
+        name: '그럭저럭',
+      } as Condition,
+    ];
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('레시피 목록이 없으면 빈 배열을 반환해야 함', async () => {
+      recipeRepository.find.mockResolvedValue([]);
+
+      const result = await service.getRecipeList();
+
+      expect(result.items).toEqual([]);
+      expect(recipeRepository.find).toHaveBeenCalledWith({
+        where: { deletedAt: IsNull() },
+        order: { id: 'ASC' },
+      });
+    });
+
+    it('레시피 목록을 정상적으로 반환해야 함', async () => {
+      recipeRepository.find.mockResolvedValue(mockRecipes);
+      recipeImageRepository.find.mockResolvedValue(mockImages);
+      recipeIngredientRepository.find.mockResolvedValue(mockRecipeIngredients);
+      recipeSeasoningRepository.find.mockResolvedValue(mockRecipeSeasonings);
+      recipeToolRepository.find.mockResolvedValue(mockRecipeTools);
+      recipeStepRepository.find.mockResolvedValue(mockSteps);
+      recipeRecommendationConditionRepository.find.mockResolvedValue(
+        mockRecipeRecommendationConditions,
+      );
+      ingredientRepository.find.mockResolvedValue(mockIngredients);
+      seasoningRepository.find.mockResolvedValue(mockSeasonings);
+      toolRepository.find.mockResolvedValue(mockTools);
+      conditionRepository.find.mockResolvedValue(mockConditions);
+
+      const result = await service.getRecipeList();
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].id).toBe(1);
+      expect(result.items[0].title).toBe('레시피 1');
+      expect(result.items[0].imageUrl).toBe('https://example.com/image1.jpg');
+      expect(result.items[0].duration).toBe(15);
+      expect(result.items[0].condition).toBe('그럭저럭');
+      expect(result.items[0].description).toBe('설명 1');
+      expect(result.items[0].tools).toHaveLength(1);
+      expect(result.items[0].tools[0].name).toBe('도구1');
+      expect(result.items[0].ingredients).toHaveLength(2);
+      expect(result.items[0].ingredients[0].name).toBe('재료1');
+      expect(result.items[0].ingredients[0].amount).toBe('100g');
+      expect(result.items[0].ingredients[0].isAlternative).toBe(false);
+      expect(result.items[0].seasonings).toHaveLength(1);
+      expect(result.items[0].seasonings[0].name).toBe('양념1');
+      expect(result.items[0].steps).toHaveLength(2);
+      expect(result.items[0].steps[0].orderNum).toBe(1);
+      expect(result.items[0].steps[0].summary).toBe('요약 1');
+      expect(result.items[0].steps[0].content).toBe('내용 1');
+      expect(result.items[0].steps[0].imageUrl).toBe(
+        'https://example.com/step1.jpg',
+      );
+    });
+
+    it('레시피가 이미지가 없으면 imageUrl이 null이어야 함', async () => {
+      const recipesWithoutImages = [
+        {
+          id: 1,
+          title: '레시피 1',
+          description: '설명 1',
+          duration: 15,
+          deletedAt: null,
+        } as Recipe,
+      ];
+
+      recipeRepository.find.mockResolvedValue(recipesWithoutImages);
+      recipeImageRepository.find.mockResolvedValue([]);
+      recipeIngredientRepository.find.mockResolvedValue([]);
+      recipeSeasoningRepository.find.mockResolvedValue([]);
+      recipeToolRepository.find.mockResolvedValue([]);
+      recipeStepRepository.find.mockResolvedValue([]);
+      recipeRecommendationConditionRepository.find.mockResolvedValue([]);
+      ingredientRepository.find.mockResolvedValue([]);
+      seasoningRepository.find.mockResolvedValue([]);
+      toolRepository.find.mockResolvedValue([]);
+      conditionRepository.find.mockResolvedValue([]);
+
+      const result = await service.getRecipeList();
+
+      expect(result.items[0].imageUrl).toBeNull();
+    });
+
+    it('레시피가 컨디션이 없으면 condition이 null이어야 함', async () => {
+      const recipesWithoutCondition = [
+        {
+          id: 1,
+          title: '레시피 1',
+          description: '설명 1',
+          duration: 15,
+          deletedAt: null,
+        } as Recipe,
+      ];
+
+      recipeRepository.find.mockResolvedValue(recipesWithoutCondition);
+      recipeImageRepository.find.mockResolvedValue([]);
+      recipeIngredientRepository.find.mockResolvedValue([]);
+      recipeSeasoningRepository.find.mockResolvedValue([]);
+      recipeToolRepository.find.mockResolvedValue([]);
+      recipeStepRepository.find.mockResolvedValue([]);
+      recipeRecommendationConditionRepository.find.mockResolvedValue([]);
+      ingredientRepository.find.mockResolvedValue([]);
+      seasoningRepository.find.mockResolvedValue([]);
+      toolRepository.find.mockResolvedValue([]);
+      conditionRepository.find.mockResolvedValue([]);
+
+      const result = await service.getRecipeList();
+
+      expect(result.items[0].condition).toBeNull();
+    });
+
+    it('레시피가 ID 오름차순으로 정렬되어야 함', async () => {
+      const recipes = [
+        {
+          id: 3,
+          title: '레시피 3',
+          description: '설명 3',
+          duration: 25,
+          deletedAt: null,
+        } as Recipe,
+        {
+          id: 1,
+          title: '레시피 1',
+          description: '설명 1',
+          duration: 15,
+          deletedAt: null,
+        } as Recipe,
+        {
+          id: 2,
+          title: '레시피 2',
+          description: '설명 2',
+          duration: 20,
+          deletedAt: null,
+        } as Recipe,
+      ];
+
+      recipeRepository.find.mockResolvedValue(recipes);
+      recipeImageRepository.find.mockResolvedValue([]);
+      recipeIngredientRepository.find.mockResolvedValue([]);
+      recipeSeasoningRepository.find.mockResolvedValue([]);
+      recipeToolRepository.find.mockResolvedValue([]);
+      recipeStepRepository.find.mockResolvedValue([]);
+      recipeRecommendationConditionRepository.find.mockResolvedValue([]);
+      ingredientRepository.find.mockResolvedValue([]);
+      seasoningRepository.find.mockResolvedValue([]);
+      toolRepository.find.mockResolvedValue([]);
+      conditionRepository.find.mockResolvedValue([]);
+
+      const result = await service.getRecipeList();
+
+      expect(result.items[0].id).toBe(3);
+      expect(result.items[1].id).toBe(1);
+      expect(result.items[2].id).toBe(2);
     });
   });
 });

--- a/src/api/recipe/recipe.service.ts
+++ b/src/api/recipe/recipe.service.ts
@@ -17,12 +17,16 @@ import { Tool } from '@/database/entity/tool.entity';
 import { UserRecipeBookmark } from '@/database/entity/user-recipe-bookmark.entity';
 import { HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { In, IsNull, Repository } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
 import { CommonCodeService } from '../common-code/common-code.service';
 import { FileCleanupService } from '../file-cleanup/file-cleanup.service';
 import { CreateRecipeDto, UpdateRecipeDto } from './dto/create-recipe.dto';
 import { GetRecipeIngredientsResponseDto } from './dto/get-recipe-ingredients.dto';
+import {
+  GetRecipeListResponseDto,
+  RecipeListItemDto,
+} from './dto/get-recipe-list.dto';
 import { GetRecipeSeasoningsResponseDto } from './dto/get-recipe-seasonings.dto';
 import { GetRecipeToolsResponseDto } from './dto/get-recipe-tools.dto';
 import {
@@ -901,5 +905,243 @@ export class RecipeService {
       }
       throw new CustomException(ERROR_CODES.RECIPE_DELETE_FAILED);
     }
+  }
+
+  /**
+   * 어드민용 레시피 목록 조회
+   */
+  async getRecipeList(): Promise<GetRecipeListResponseDto> {
+    // 레시피 목록 조회 (삭제되지 않은 모든 레시피)
+    const recipes = await this.recipeRepository.find({
+      where: { deletedAt: IsNull() },
+      order: { id: 'ASC' },
+    });
+
+    if (recipes.length === 0) {
+      return {
+        items: [],
+      };
+    }
+
+    const recipeIds = recipes.map((r) => r.id);
+
+    // 관련 데이터 일괄 조회
+    const [
+      images,
+      recipeIngredients,
+      recipeSeasonings,
+      recipeTools,
+      steps,
+      recipeRecommendationConditions,
+    ] = await Promise.all([
+      this.recipeImageRepository.find({
+        where: { recipeId: In(recipeIds) },
+        order: { id: 'ASC' },
+      }),
+      this.recipeIngredientRepository.find({
+        where: { recipeId: In(recipeIds) },
+      }),
+      this.recipeSeasoningRepository.find({
+        where: { recipeId: In(recipeIds) },
+      }),
+      this.recipeToolRepository.find({
+        where: { recipeId: In(recipeIds) },
+      }),
+      this.recipeStepRepository.find({
+        where: { recipeId: In(recipeIds) },
+        order: { orderNum: 'ASC' },
+      }),
+      this.recipeRecommendationConditionRepository.find({
+        where: { recipeId: In(recipeIds) },
+        order: { priorityScore: 'DESC' },
+      }),
+    ]);
+
+    // 재료, 양념, 도구 정보 조회
+    const ingredientIds = [
+      ...new Set(recipeIngredients.map((ri) => ri.ingredientId)),
+    ];
+    const seasoningIds = [
+      ...new Set(recipeSeasonings.map((rs) => rs.seasoningId)),
+    ];
+    const toolIds = [...new Set(recipeTools.map((rt) => rt.toolId))];
+
+    const [ingredients, seasonings, tools, conditions] = await Promise.all([
+      ingredientIds.length
+        ? this.ingredientRepository.find({ where: { id: In(ingredientIds) } })
+        : [],
+      seasoningIds.length
+        ? this.seasoningRepository.find({ where: { id: In(seasoningIds) } })
+        : [],
+      toolIds.length
+        ? this.toolRepository.find({ where: { id: In(toolIds) } })
+        : [],
+      this.conditionRepository.find(),
+    ]);
+
+    // 맵 생성
+    const ingredientMap = new Map<number, Ingredient>();
+    ingredients.forEach((i) => ingredientMap.set(i.id, i));
+
+    const seasoningMap = new Map<number, Seasoning>();
+    seasonings.forEach((s) => seasoningMap.set(s.id, s));
+
+    const toolMap = new Map<number, Tool>();
+    tools.forEach((t) => toolMap.set(t.id, t));
+
+    const conditionMap = new Map<number, string>();
+    conditions.forEach((c) => conditionMap.set(c.id, c.name));
+
+    // 레시피별로 데이터 그룹화
+    const imagesByRecipe = new Map<number, RecipeImage[]>();
+    const ingredientsByRecipe = new Map<number, RecipeIngredient[]>();
+    const seasoningsByRecipe = new Map<number, RecipeSeasoning[]>();
+    const toolsByRecipe = new Map<number, RecipeTool[]>();
+    const stepsByRecipe = new Map<number, RecipeStep[]>();
+    const conditionsByRecipe = new Map<
+      number,
+      RecipeRecommendationCondition[]
+    >();
+
+    images.forEach((img) => {
+      const list = imagesByRecipe.get(img.recipeId) || [];
+      list.push(img);
+      imagesByRecipe.set(img.recipeId, list);
+    });
+
+    recipeIngredients.forEach((ri) => {
+      const list = ingredientsByRecipe.get(ri.recipeId) || [];
+      list.push(ri);
+      ingredientsByRecipe.set(ri.recipeId, list);
+    });
+
+    recipeSeasonings.forEach((rs) => {
+      const list = seasoningsByRecipe.get(rs.recipeId) || [];
+      list.push(rs);
+      seasoningsByRecipe.set(rs.recipeId, list);
+    });
+
+    recipeTools.forEach((rt) => {
+      const list = toolsByRecipe.get(rt.recipeId) || [];
+      list.push(rt);
+      toolsByRecipe.set(rt.recipeId, list);
+    });
+
+    steps.forEach((step) => {
+      const list = stepsByRecipe.get(step.recipeId) || [];
+      list.push(step);
+      stepsByRecipe.set(step.recipeId, list);
+    });
+
+    recipeRecommendationConditions.forEach((rc) => {
+      const list = conditionsByRecipe.get(rc.recipeId) || [];
+      list.push(rc);
+      conditionsByRecipe.set(rc.recipeId, list);
+    });
+
+    // 응답 데이터 생성
+    const items: RecipeListItemDto[] = recipes.map((recipe) => {
+      const recipeImages = imagesByRecipe.get(recipe.id) || [];
+      const recipeIngredientsList = ingredientsByRecipe.get(recipe.id) || [];
+      const recipeSeasoningsList = seasoningsByRecipe.get(recipe.id) || [];
+      const recipeToolsList = toolsByRecipe.get(recipe.id) || [];
+      const recipeSteps = stepsByRecipe.get(recipe.id) || [];
+      const recipeConditions = conditionsByRecipe.get(recipe.id) || [];
+
+      // 첫 번째 이미지 URL
+      const firstImage = recipeImages[0];
+      const imageUrl = firstImage?.imageUrl || null;
+
+      // 가장 높은 우선순위의 컨디션 이름
+      const primaryCondition = recipeConditions[0];
+      const conditionName = primaryCondition
+        ? conditionMap.get(primaryCondition.conditionId) || null
+        : null;
+
+      // 조리도구 DTO 배열 생성
+      const tools = recipeToolsList
+        .map((rt) => {
+          const tool = toolMap.get(rt.toolId);
+          return tool
+            ? {
+                id: tool.id,
+                name: tool.name,
+                imageUrl: tool.imageUrl,
+              }
+            : null;
+        })
+        .filter(
+          (tool): tool is { id: number; name: string; imageUrl: string } =>
+            tool !== null,
+        );
+
+      // 재료 DTO 배열 생성
+      const ingredients = recipeIngredientsList
+        .map((ri) => {
+          const ingredient = ingredientMap.get(ri.ingredientId);
+          return ingredient
+            ? {
+                id: ingredient.id,
+                name: ingredient.name,
+                amount: ri.amount,
+                isAlternative: ri.isAlternative,
+              }
+            : null;
+        })
+        .filter(
+          (
+            ing,
+          ): ing is {
+            id: number;
+            name: string;
+            amount: string;
+            isAlternative: boolean;
+          } => ing !== null,
+        );
+
+      // 양념 DTO 배열 생성
+      const seasonings = recipeSeasoningsList
+        .map((rs) => {
+          const seasoning = seasoningMap.get(rs.seasoningId);
+          return seasoning
+            ? {
+                id: seasoning.id,
+                name: seasoning.name,
+                amount: rs.amount,
+              }
+            : null;
+        })
+        .filter(
+          (sea): sea is { id: number; name: string; amount: string } =>
+            sea !== null,
+        );
+
+      // Step 데이터 생성 (순서대로 정렬)
+      const steps = recipeSteps
+        .sort((a, b) => a.orderNum - b.orderNum)
+        .map((step) => ({
+          orderNum: step.orderNum,
+          summary: step.summary,
+          content: step.content,
+          imageUrl: step.imageUrl,
+        }));
+
+      return {
+        id: recipe.id,
+        title: recipe.title,
+        imageUrl,
+        duration: recipe.duration,
+        condition: conditionName,
+        description: recipe.description,
+        tools,
+        ingredients,
+        seasonings,
+        steps,
+      };
+    });
+
+    return {
+      items,
+    };
   }
 }


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- GET /v1/recipes 엔드포인트 추가 (어드민 전용)
- 레시피 목록을 ID 오름차순으로 반환
- 페이징 없이 모든 레시피 반환

### ✨ 변경 내용  
---  
- [ ] (변경된 사항 요약) 
- [ ] (새로 추가된 기능이나 수정된 내용)  
- [ ] (리팩토링 및 코드 개선 사항)  

### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 관리자 전용 레시피 목록 조회 엔드포인트 추가
  * 각 레시피에 도구, 재료, 양념, 순서화된 조리 단계 및 대표 이미지/조건/조리 시간 포함된 응답 반환

* **테스트**
  * 레시피 목록 조회에 대한 종합 단위 테스트 추가
  * 빈 목록, 이미지·조건 누락, 정렬 등 여러 케이스 검증

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->