### PR TITLE
feat: 레시피 일괄 삭제 API 추가 및 단일 삭제 API 제거

### DIFF
--- a/src/api/recipe/dto/delete-recipes.dto.ts
+++ b/src/api/recipe/dto/delete-recipes.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayNotEmpty, IsArray, IsInt, IsNumber } from 'class-validator';
+
+export class DeleteRecipesRequestDto {
+  @ApiProperty({
+    description: '삭제할 레시피 ID 배열',
+    example: [1, 2, 3],
+    type: [Number],
+  })
+  @IsArray()
+  @ArrayNotEmpty({ message: '최소 1개 이상의 레시피 ID가 필요합니다' })
+  @IsNumber({}, { each: true })
+  @IsInt({ each: true })
+  recipeIds: number[];
+}
+
+export class DeleteRecipesResponseDto {
+  @ApiProperty({
+    description: '삭제된 레시피 개수',
+    example: 3,
+  })
+  deletedCount: number;
+
+  @ApiProperty({
+    description: '삭제된 레시피 ID 목록',
+    example: [1, 2, 3],
+    type: [Number],
+  })
+  deletedIds: number[];
+
+  @ApiProperty({
+    description: '삭제 실패한 레시피 ID 목록',
+    example: [],
+    type: [Number],
+  })
+  failedIds: number[];
+}

--- a/src/api/recipe/recipe.controller.ts
+++ b/src/api/recipe/recipe.controller.ts
@@ -36,6 +36,10 @@ import { UserRole } from '../user/enums/role.enum';
 import { CreateRecipeRecommendationConditionRequest } from './dto/create-recipe-recommend-request.dto';
 import { CreateRecipeRecommendationConditionDto } from './dto/create-recipe-recommend.dto';
 import { CreateRecipeDto, UpdateRecipeDto } from './dto/create-recipe.dto';
+import {
+  DeleteRecipesRequestDto,
+  DeleteRecipesResponseDto,
+} from './dto/delete-recipes.dto';
 import { GetRecipeIngredientsResponseDto } from './dto/get-recipe-ingredients.dto';
 import { GetRecipeRecommendationRequestDto } from './dto/get-recipe-recommendation-request.dto';
 import { GetRecipeRecommendationResponseDto } from './dto/get-recipe-recommendation-response.dto';
@@ -323,35 +327,30 @@ export class RecipeController {
     return await this.recipeService.updateRecipe(id, updateRecipeDto);
   }
 
-  @Delete(':id')
+  @Delete('')
   @UseGuards(JwtGuard, RolesGuard)
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth('Authorization')
   @ApiOperation({
-    summary: '[어드민] 레시피 삭제',
+    summary: '[어드민] 레시피 일괄 삭제',
     description:
-      '레시피를 삭제합니다. Soft Delete 방식으로 처리되며, 관련 추천 캐시도 자동으로 무효화됩니다.',
+      '여러 레시피를 한 번에 삭제합니다. Soft Delete 방식으로 처리되며, 관련 추천 캐시도 자동으로 무효화됩니다.',
   })
-  @ApiParam({
-    name: 'id',
-    description: '삭제할 레시피 ID',
-    type: 'number',
-    example: 1,
+  @ApiBody({
+    description: '삭제할 레시피 ID 배열',
+    type: DeleteRecipesRequestDto,
   })
-  @ApiSuccessResponse('레시피 삭제 성공', {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: '레시피가 삭제되었습니다.' },
-    },
+  @ApiSuccessResponse('레시피 일괄 삭제 성공', {
+    type: DeleteRecipesResponseDto,
   })
+  @ApiErrorResponse(400, ERROR_CODES.VALIDATION_ERROR)
   @ApiErrorResponse(401, ERROR_CODES.AUTH_REQUIRED)
   @ApiErrorResponse(403, ERROR_CODES.AUTH_PERMISSION_DENIED)
-  @ApiErrorResponse(404, ERROR_CODES.RECIPE_NOT_FOUND)
-  async deleteRecipe(
-    @Param('id', ParseIntPipe) id: number,
-  ): Promise<{ message: string }> {
-    await this.recipeService.deleteRecipe(id);
-    return { message: '레시피가 삭제되었습니다.' };
+  @ApiErrorResponse(500, ERROR_CODES.RECIPE_DELETE_FAILED)
+  async deleteRecipes(
+    @Body() dto: DeleteRecipesRequestDto,
+  ): Promise<DeleteRecipesResponseDto> {
+    return await this.recipeService.deleteRecipes(dto.recipeIds);
   }
 
   @Get('/public/:id')

--- a/src/api/recipe/recipe.service.spec.ts
+++ b/src/api/recipe/recipe.service.spec.ts
@@ -521,4 +521,194 @@ describe('RecipeService', () => {
       ).toBeTruthy();
     });
   });
+
+  describe('deleteRecipes', () => {
+    const recipeIds = [1, 2, 3];
+
+    it('레시피 일괄 삭제 성공 시 캐시 무효화를 호출해야 함', async () => {
+      const existingRecipes = [
+        {
+          id: 1,
+          title: '레시피 1',
+          description: '설명 1',
+          duration: 30,
+          deletedAt: null,
+        } as Recipe,
+        {
+          id: 2,
+          title: '레시피 2',
+          description: '설명 2',
+          duration: 30,
+          deletedAt: null,
+        } as Recipe,
+        {
+          id: 3,
+          title: '레시피 3',
+          description: '설명 3',
+          duration: 30,
+          deletedAt: null,
+        } as Recipe,
+      ];
+
+      recipeRepository.find.mockResolvedValue(existingRecipes);
+      recipeRepository.softDelete.mockResolvedValue({ affected: 3 } as any);
+
+      const result = await service.deleteRecipes(recipeIds);
+
+      expect(result.deletedCount).toBe(3);
+      expect(result.deletedIds).toEqual([1, 2, 3]);
+      expect(result.failedIds).toEqual([]);
+      expect(recipeRepository.softDelete).toHaveBeenCalledWith([1, 2, 3]);
+      expect(
+        recipeRecommendationService.invalidateCacheByRecipeId,
+      ).toHaveBeenCalledTimes(3);
+      expect(
+        recipeRecommendationService.invalidateCacheByRecipeId,
+      ).toHaveBeenCalledWith(1);
+      expect(
+        recipeRecommendationService.invalidateCacheByRecipeId,
+      ).toHaveBeenCalledWith(2);
+      expect(
+        recipeRecommendationService.invalidateCacheByRecipeId,
+      ).toHaveBeenCalledWith(3);
+    });
+
+    it('존재하지 않는 레시피 ID는 failedIds에 포함되어야 함', async () => {
+      const existingRecipes = [
+        {
+          id: 1,
+          title: '레시피 1',
+          description: '설명 1',
+          duration: 30,
+          deletedAt: null,
+        } as Recipe,
+      ];
+
+      recipeRepository.find.mockResolvedValue(existingRecipes);
+      recipeRepository.softDelete.mockResolvedValue({ affected: 1 } as any);
+
+      const result = await service.deleteRecipes([1, 2, 3, 999]);
+
+      expect(result.deletedCount).toBe(1);
+      expect(result.deletedIds).toEqual([1]);
+      expect(result.failedIds).toEqual([2, 3, 999]);
+      expect(recipeRepository.softDelete).toHaveBeenCalledWith([1]);
+    });
+
+    it('중복된 ID는 자동으로 제거되어야 함', async () => {
+      const existingRecipes = [
+        {
+          id: 1,
+          title: '레시피 1',
+          description: '설명 1',
+          duration: 30,
+          deletedAt: null,
+        } as Recipe,
+      ];
+
+      recipeRepository.find.mockResolvedValue(existingRecipes);
+      recipeRepository.softDelete.mockResolvedValue({ affected: 1 } as any);
+
+      const result = await service.deleteRecipes([1, 1, 1, 2, 2]);
+
+      expect(result.deletedCount).toBe(1);
+      expect(result.deletedIds).toEqual([1]);
+      expect(result.failedIds).toEqual([2]);
+      expect(recipeRepository.softDelete).toHaveBeenCalledWith([1]);
+    });
+
+    it('존재하는 레시피가 없으면 빈 결과를 반환해야 함', async () => {
+      recipeRepository.find.mockResolvedValue([]);
+
+      const result = await service.deleteRecipes([999, 1000]);
+
+      expect(result.deletedCount).toBe(0);
+      expect(result.deletedIds).toEqual([]);
+      expect(result.failedIds).toEqual([999, 1000]);
+      expect(recipeRepository.softDelete).not.toHaveBeenCalled();
+      expect(
+        recipeRecommendationService.invalidateCacheByRecipeId,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('빈 배열이면 에러를 발생시켜야 함', async () => {
+      await expect(service.deleteRecipes([])).rejects.toThrow(CustomException);
+
+      expect(recipeRepository.softDelete).not.toHaveBeenCalled();
+      expect(
+        recipeRecommendationService.invalidateCacheByRecipeId,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('유효하지 않은 ID는 필터링되어야 함', async () => {
+      const existingRecipes = [
+        {
+          id: 1,
+          title: '레시피 1',
+          description: '설명 1',
+          duration: 30,
+          deletedAt: null,
+        } as Recipe,
+      ];
+
+      recipeRepository.find.mockResolvedValue(existingRecipes);
+      recipeRepository.softDelete.mockResolvedValue({ affected: 1 } as any);
+
+      const result = await service.deleteRecipes([
+        1,
+        -1,
+        0,
+        1.5,
+        null,
+        undefined,
+      ] as any);
+
+      expect(result.deletedCount).toBe(1);
+      expect(result.deletedIds).toEqual([1]);
+      expect(recipeRepository.softDelete).toHaveBeenCalledWith([1]);
+    });
+
+    it('이미 삭제된 레시피는 제외되어야 함', async () => {
+      const existingRecipes = [
+        {
+          id: 1,
+          title: '레시피 1',
+          description: '설명 1',
+          duration: 30,
+          deletedAt: null,
+        } as Recipe,
+      ];
+
+      // 삭제된 레시피는 find에서 제외됨 (deletedAt: IsNull() 조건)
+      recipeRepository.find.mockResolvedValue(existingRecipes);
+      recipeRepository.softDelete.mockResolvedValue({ affected: 1 } as any);
+
+      const result = await service.deleteRecipes([1, 2]);
+
+      expect(result.deletedCount).toBe(1);
+      expect(result.deletedIds).toEqual([1]);
+      expect(result.failedIds).toEqual([2]);
+    });
+
+    it('삭제 실패 시 에러를 발생시켜야 함', async () => {
+      const existingRecipes = [
+        {
+          id: 1,
+          title: '레시피 1',
+          description: '설명 1',
+          duration: 30,
+          deletedAt: null,
+        } as Recipe,
+      ];
+
+      recipeRepository.find.mockResolvedValue(existingRecipes);
+      recipeRepository.softDelete.mockRejectedValue(new Error('DB 에러'));
+
+      await expect(service.deleteRecipes([1])).rejects.toThrow(CustomException);
+
+      expect(
+        recipeRecommendationService.invalidateCacheByRecipeId,
+      ).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/api/recipe/recipe.service.ts
+++ b/src/api/recipe/recipe.service.ts
@@ -17,7 +17,7 @@ import { Tool } from '@/database/entity/tool.entity';
 import { UserRecipeBookmark } from '@/database/entity/user-recipe-bookmark.entity';
 import { HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { In, IsNull, Repository } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
 import { CommonCodeService } from '../common-code/common-code.service';
 import { FileCleanupService } from '../file-cleanup/file-cleanup.service';
@@ -896,6 +896,74 @@ export class RecipeService {
       this.logger.log(`레시피 ${recipeId} 삭제 완료 및 캐시 무효화 완료`);
     } catch (error) {
       this.logger.error('레시피 삭제 중 에러 발생', error);
+      if (error instanceof CustomException) {
+        throw error;
+      }
+      throw new CustomException(ERROR_CODES.RECIPE_DELETE_FAILED);
+    }
+  }
+
+  /**
+   * 레시피 일괄 삭제 (Soft Delete)
+   * 삭제 시 관련 추천 캐시를 무효화합니다.
+   */
+  @Transactional()
+  async deleteRecipes(recipeIds: number[]): Promise<{
+    deletedCount: number;
+    deletedIds: number[];
+    failedIds: number[];
+  }> {
+    try {
+      if (!recipeIds || recipeIds.length === 0) {
+        throw new CustomException(ERROR_CODES.VALIDATION_ERROR);
+      }
+
+      // 중복 제거 및 유효성 검사
+      const uniqueIds = Array.from(new Set(recipeIds)).filter(
+        (id) => Number.isInteger(id) && id > 0,
+      );
+
+      if (uniqueIds.length === 0) {
+        throw new CustomException(ERROR_CODES.VALIDATION_ERROR);
+      }
+
+      // 존재하는 레시피 확인
+      const existingRecipes = await this.recipeRepository.find({
+        where: { id: In(uniqueIds), deletedAt: IsNull() },
+      });
+
+      const existingIds = existingRecipes.map((r) => r.id);
+      const notFoundIds = uniqueIds.filter((id) => !existingIds.includes(id));
+
+      if (existingIds.length === 0) {
+        return {
+          deletedCount: 0,
+          deletedIds: [],
+          failedIds: uniqueIds,
+        };
+      }
+
+      // Soft delete 수행
+      await this.recipeRepository.softDelete(existingIds);
+
+      // 각 레시피의 추천 캐시 무효화
+      await Promise.all(
+        existingIds.map((id) =>
+          this.recipeRecommendationService.invalidateCacheByRecipeId(id),
+        ),
+      );
+
+      this.logger.log(
+        `레시피 일괄 삭제 완료: ${existingIds.length}개 성공, ${notFoundIds.length}개 실패`,
+      );
+
+      return {
+        deletedCount: existingIds.length,
+        deletedIds: existingIds,
+        failedIds: notFoundIds,
+      };
+    } catch (error) {
+      this.logger.error('레시피 일괄 삭제 중 에러 발생', error);
       if (error instanceof CustomException) {
         throw error;
       }


### PR DESCRIPTION
### 🚀 Pull Request  
---  
- 레시피 일괄 삭제 API 추가 및 단일 삭제 API 제거

### ✨ 변경 내용  
---  
- [ ] (변경된 사항 요약) 
- [ ] (새로 추가된 기능이나 수정된 내용)  
- [ ] (리팩토링 및 코드 개선 사항)  

### 🛠 테스트 방법  
---   
1. (테스트 환경 준비)  
2. (API 요청 예시 및 기대 응답)  
3. (기능 테스트 방법)  

### 📌 관련 이슈  
---  
- #(관련 이슈 번호)  

### 📎 참고 사항  
---  
- 변경된 API 문서 링크  
- 관련된 디자인 또는 기획 문서 링크  
- 추가적인 설명이 필요한 부분  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 레시피 일괄 삭제 기능 추가: 여러 개의 레시피를 한 번에 삭제할 수 있습니다. 삭제 결과에서 성공한 항목과 실패한 항목을 구분하여 반환합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->